### PR TITLE
Add on-demand database sync workflow from prod to preprod

### DIFF
--- a/.github/workflows/sync-db.yml
+++ b/.github/workflows/sync-db.yml
@@ -1,0 +1,32 @@
+name: Sync DB Prod → Preprod
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: "Type 'yes' to confirm overwriting the preprod database with production data"
+        required: true
+        type: string
+
+jobs:
+  sync-db:
+    name: Copy Prod DB to Preprod
+    if: github.event.inputs.confirm == 'yes'
+    runs-on: ubuntu-latest
+    environment: preprod
+    timeout-minutes: 15
+
+    steps:
+      - name: Sync database via SSH
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          port: ${{ secrets.DEPLOY_SSH_PORT }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          command_timeout: 10m
+          script: |
+            set -e
+            echo "=== Starting DB sync: prod → preprod ==="
+            /opt/houseflow/scripts/sync-db-to-preprod.sh
+            echo "=== DB sync completed ==="

--- a/infrastructure/setup-vm.sh
+++ b/infrastructure/setup-vm.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 #   3. Create directory structure (/opt/houseflow)
 #   4. Generate docker-compose files for prod + preprod
 #   5. Generate .env with random secrets
-#   6. Install deployment scripts (backup, db sync)
+#   6. Install deployment scripts (backup, on-demand db sync)
 #   7. Configure systemd timer for daily backups + logrotate
 #   8. Configure firewall (ufw)
 # ============================================================================

--- a/scripts/sync-db-to-preprod.sh
+++ b/scripts/sync-db-to-preprod.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Copy production database to preprod
-# Called before each preprod deployment
+# Triggered on-demand via GitHub Actions workflow (sync-db.yml)
 
 PROD_COMPOSE="/opt/houseflow/prod/docker-compose.yaml"
 PREPROD_COMPOSE="/opt/houseflow/preprod/docker-compose.yaml"


### PR DESCRIPTION
## Summary
This PR introduces an on-demand GitHub Actions workflow to manually sync the production database to the preprod environment, replacing the previous approach of syncing before each preprod deployment.

## Key Changes
- **New GitHub Actions workflow** (`.github/workflows/sync-db.yml`): Adds a `workflow_dispatch` triggered workflow that allows manual database synchronization from prod to preprod with a confirmation prompt to prevent accidental overwrites
- **Updated deployment script documentation**: Modified `scripts/sync-db-to-preprod.sh` to reflect that it's now triggered on-demand via GitHub Actions instead of before each preprod deployment
- **Updated setup documentation**: Updated `infrastructure/setup-vm.sh` comment to clarify that deployment scripts now support "on-demand db sync" rather than just automatic syncing

## Implementation Details
- The workflow requires explicit confirmation by typing 'yes' as an input parameter to prevent accidental database overwrites
- Uses SSH action to execute the existing `sync-db-to-preprod.sh` script on the deployment host
- Configured with a 15-minute timeout and runs in the preprod environment context
- The SSH command has a 10-minute timeout with error handling (`set -e`)

https://claude.ai/code/session_01CMR2Sz9DNFvi3SJar62m7T