### PR TITLE
Inject API URL at runtime via server layout

### DIFF
--- a/src/HouseFlow.Frontend/next.config.ts
+++ b/src/HouseFlow.Frontend/next.config.ts
@@ -23,6 +23,10 @@ const nextConfig: NextConfig = {
         protocol: 'https',
         hostname: 'localhost',
       },
+      {
+        protocol: 'https',
+        hostname: 'api.houseflow.rouss.be',
+      },
     ],
   },
   reactStrictMode: true,

--- a/src/HouseFlow.Frontend/src/app/[locale]/layout.tsx
+++ b/src/HouseFlow.Frontend/src/app/[locale]/layout.tsx
@@ -25,8 +25,18 @@ export default async function LocaleLayout({
   // side is the easiest way to get started
   const messages = await getMessages();
 
+  // Runtime API URL injection (server-side env vars aren't available client-side in Next.js)
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5203';
+
   return (
     <html lang={locale} suppressHydrationWarning>
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `window.__RUNTIME_CONFIG__ = { API_URL: ${JSON.stringify(apiUrl)} };`,
+          }}
+        />
+      </head>
       <body className="font-sans antialiased">
         <NextIntlClientProvider messages={messages}>
           <ThemeProvider

--- a/src/HouseFlow.Frontend/src/lib/api/client.ts
+++ b/src/HouseFlow.Frontend/src/lib/api/client.ts
@@ -1,7 +1,20 @@
 import axios, { AxiosError, InternalAxiosRequestConfig } from 'axios';
 
-// Get API URL from environment (injected by Aspire)
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5203';
+declare global {
+  interface Window {
+    __RUNTIME_CONFIG__?: { API_URL: string };
+  }
+}
+
+// Get API URL: runtime config (injected by server layout) > env var > fallback
+function getApiUrl(): string {
+  if (typeof window !== 'undefined' && window.__RUNTIME_CONFIG__?.API_URL) {
+    return window.__RUNTIME_CONFIG__.API_URL;
+  }
+  return process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5203';
+}
+
+const API_URL = getApiUrl();
 
 // Token storage key
 const ACCESS_TOKEN_KEY = 'houseflow_access_token';


### PR DESCRIPTION
## Summary
This PR improves API URL configuration handling by injecting the API URL at runtime through the server layout, making it available to client-side code without relying solely on build-time environment variables.

## Key Changes
- **API Client Configuration**: Modified `src/lib/api/client.ts` to support runtime API URL injection via `window.__RUNTIME_CONFIG__` while maintaining fallback to environment variables and a default localhost URL
- **Server Layout Injection**: Updated `src/app/[locale]/layout.tsx` to inject the API URL as a global runtime configuration in the HTML head, making it accessible to client-side code
- **Image Domain Configuration**: Added `api.houseflow.rouss.be` to the allowed image domains in `next.config.ts`

## Implementation Details
- Added a TypeScript global interface declaration to properly type the `window.__RUNTIME_CONFIG__` object
- Implemented a `getApiUrl()` function that checks for runtime config first, then falls back to environment variables and a default value
- The runtime injection happens server-side in the layout, ensuring the API URL is available before client-side code executes
- This approach solves the limitation where server-side environment variables aren't directly accessible to client-side code in Next.js

https://claude.ai/code/session_01Dz7uaiBzGm8DQdfQtSUCVT