### PR TITLE
fix: use runtime API URL instead of build-time env vars

### DIFF
--- a/infrastructure/docker-compose.preprod.yaml
+++ b/infrastructure/docker-compose.preprod.yaml
@@ -40,7 +40,7 @@ services:
     ports:
       - "0.0.0.0:3100:3000"
     environment:
-      - NEXT_PUBLIC_API_URL=${API_PUBLIC_URL:-http://localhost:8180}
+      - API_URL=${API_PUBLIC_URL:-http://localhost:8180}
     depends_on:
       api:
         condition: service_healthy

--- a/infrastructure/docker-compose.prod.yaml
+++ b/infrastructure/docker-compose.prod.yaml
@@ -40,7 +40,7 @@ services:
     ports:
       - "0.0.0.0:3000:3000"
     environment:
-      - NEXT_PUBLIC_API_URL=${API_PUBLIC_URL:-http://localhost:8080}
+      - API_URL=${API_PUBLIC_URL:-http://localhost:8080}
     depends_on:
       api:
         condition: service_healthy

--- a/src/HouseFlow.Frontend/next.config.ts
+++ b/src/HouseFlow.Frontend/next.config.ts
@@ -6,12 +6,14 @@ const withNextIntl = createNextIntlPlugin();
 const nextConfig: NextConfig = {
   output: 'standalone',
   env: {
-    // Aspire injects service URLs via environment variables
-    // services__api__https__0 for HTTPS endpoint
-    // services__api__http__0 for HTTP endpoint
-    NEXT_PUBLIC_API_URL: process.env.services__api__https__0 ||
-                         process.env.services__api__http__0 ||
-                         'http://localhost:5203',
+    // Aspire injects service URLs via environment variables (dev only)
+    // In production, API_URL is read at runtime in layout.tsx
+    ...(process.env.services__api__https__0 || process.env.services__api__http__0
+      ? {
+          NEXT_PUBLIC_API_URL:
+            process.env.services__api__https__0 || process.env.services__api__http__0,
+        }
+      : {}),
   },
   images: {
     remotePatterns: [

--- a/src/HouseFlow.Frontend/src/app/[locale]/layout.tsx
+++ b/src/HouseFlow.Frontend/src/app/[locale]/layout.tsx
@@ -25,8 +25,8 @@ export default async function LocaleLayout({
   // side is the easiest way to get started
   const messages = await getMessages();
 
-  // Runtime API URL injection (server-side env vars aren't available client-side in Next.js)
-  const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5203';
+  // Runtime API URL injection — use API_URL (not NEXT_PUBLIC_*) to avoid build-time inlining
+  const apiUrl = process.env.API_URL || process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5203';
 
   return (
     <html lang={locale} suppressHydrationWarning>


### PR DESCRIPTION
## Summary
- **Problem**: Frontend always calls localhost in production because NEXT_PUBLIC_API_URL is inlined at build time by Next.js.
- **Fix**: Inject the API URL at runtime from server layout via window.__RUNTIME_CONFIG__, using API_URL (without NEXT_PUBLIC_ prefix).
- **Docker**: Pass API_URL instead of NEXT_PUBLIC_API_URL in docker-compose.

https://claude.ai/code/session_01Dz7uaiBzGm8DQdfQtSUCVT