### PR TITLE
fix: add responsive design for mobile screens

### DIFF
--- a/src/HouseFlow.Frontend/src/app/[locale]/(auth)/login/page.tsx
+++ b/src/HouseFlow.Frontend/src/app/[locale]/(auth)/login/page.tsx
@@ -5,7 +5,7 @@ export default function LoginPage() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-900 dark:to-gray-800 px-4">
       <div className="w-full max-w-md">
-        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl p-8">
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl p-4 sm:p-8">
           <div className="text-center mb-8">
             <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
               HouseFlow

--- a/src/HouseFlow.Frontend/src/app/[locale]/(auth)/register/page.tsx
+++ b/src/HouseFlow.Frontend/src/app/[locale]/(auth)/register/page.tsx
@@ -4,7 +4,7 @@ export default function RegisterPage() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-900 dark:to-gray-800 px-4">
       <div className="w-full max-w-md">
-        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl p-8">
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl p-4 sm:p-8">
           <div className="text-center mb-8">
             <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
               HouseFlow

--- a/src/HouseFlow.Frontend/src/app/[locale]/(dashboard)/devices/[id]/page.tsx
+++ b/src/HouseFlow.Frontend/src/app/[locale]/(dashboard)/devices/[id]/page.tsx
@@ -93,7 +93,7 @@ export default function DeviceDetailPage({ params }: { params: Promise<{ id: str
                 </div>
                 <div>
                   <div className="flex items-center gap-3 flex-wrap">
-                    <h1 className="text-2xl font-bold text-gray-900 dark:text-white">{device.name}</h1>
+                    <h1 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white">{device.name}</h1>
                     {overdueCount > 0 && (
                       <span className="inline-flex items-center gap-1 px-3 py-1 bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300 rounded-full text-xs font-semibold">
                         <AlertTriangle className="h-3 w-3" />

--- a/src/HouseFlow.Frontend/src/app/[locale]/(dashboard)/houses/new/page.tsx
+++ b/src/HouseFlow.Frontend/src/app/[locale]/(dashboard)/houses/new/page.tsx
@@ -30,7 +30,7 @@ export default function NewHousePage() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-8">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-4 sm:p-8">
       <div className="max-w-2xl mx-auto">
         <Card>
           <CardHeader>
@@ -77,7 +77,7 @@ export default function NewHousePage() {
                 />
               </div>
 
-              <div className="grid grid-cols-2 gap-4">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div>
                   <label htmlFor="zipCode" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                     {t('zipCode')}

--- a/src/HouseFlow.Frontend/src/app/[locale]/(dashboard)/houses/page.tsx
+++ b/src/HouseFlow.Frontend/src/app/[locale]/(dashboard)/houses/page.tsx
@@ -15,11 +15,11 @@ export default function HousesPage() {
   const houses = housesData?.houses || [];
 
   if (isLoading) {
-    return <div className="p-8">{tCommon('loading')}</div>;
+    return <div className="p-4 sm:p-8">{tCommon('loading')}</div>;
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-8">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-4 sm:p-8">
       <div className="max-w-7xl mx-auto">
         <div className="flex items-center justify-between mb-8">
           <div>

--- a/src/HouseFlow.Frontend/src/components/auth/register-form.tsx
+++ b/src/HouseFlow.Frontend/src/components/auth/register-form.tsx
@@ -60,7 +60,7 @@ export function RegisterForm() {
         </div>
       )}
 
-      <div className="grid grid-cols-2 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <div>
           <label htmlFor="firstName" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
             {t('firstName')}

--- a/src/HouseFlow.Frontend/src/components/devices/edit-device-dialog.tsx
+++ b/src/HouseFlow.Frontend/src/components/devices/edit-device-dialog.tsx
@@ -120,7 +120,7 @@ export function EditDeviceDialog({ deviceId, device, open, onClose }: EditDevice
               </select>
             </div>
 
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div>
                 <label htmlFor="edit-device-brand" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   {t("brand")} ({tCommon("optional")})

--- a/src/HouseFlow.Frontend/src/components/houses/edit-house-dialog.tsx
+++ b/src/HouseFlow.Frontend/src/components/houses/edit-house-dialog.tsx
@@ -95,7 +95,7 @@ export function EditHouseDialog({ houseId, house, open, onClose }: EditHouseDial
               />
             </div>
 
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div>
                 <label htmlFor="edit-zipCode" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   {t("zipCode")}


### PR DESCRIPTION
- Stack 2-column grids on mobile (register form, house form, edit dialogs)
- Add responsive padding (p-4 sm:p-8) on houses page, auth pages, new house form
- Scale device detail heading text for small screens

https://claude.ai/code/session_01Le4GWD9UTwgfp4PMH5U2SR