### PR TITLE
feat: harmonize empty states with reusable EmptyState component

### DIFF
--- a/src/HouseFlow.Frontend/src/app/[locale]/(dashboard)/devices/[id]/page.tsx
+++ b/src/HouseFlow.Frontend/src/app/[locale]/(dashboard)/devices/[id]/page.tsx
@@ -305,17 +305,12 @@ export default function DeviceDetailPage({ params }: { params: Promise<{ id: str
                     <ListItemSkeleton />
                   </div>
                 ) : !maintenanceHistory?.instances || maintenanceHistory.instances.length === 0 ? (
-                  <div className="flex flex-col items-center justify-center py-12 text-center">
-                    <div className="w-16 h-16 bg-gray-100 dark:bg-gray-700 rounded-full flex items-center justify-center mb-4">
-                      <Clock className="h-8 w-8 text-gray-400 dark:text-gray-500" />
-                    </div>
-                    <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
-                      {tMaintenance('noHistory')}
-                    </h3>
-                    <p className="text-sm text-gray-500 dark:text-gray-400 max-w-sm">
-                      {tMaintenance('noHistoryDescription')}
-                    </p>
-                  </div>
+                  <EmptyState
+                    variant="inline"
+                    icon={Clock}
+                    title={tMaintenance('noHistory')}
+                    description={tMaintenance('noHistoryDescription')}
+                  />
                 ) : (
                   <div className="space-y-6">
                     {[...maintenanceHistory.instances]

--- a/src/HouseFlow.Frontend/src/components/ui/empty-state.tsx
+++ b/src/HouseFlow.Frontend/src/components/ui/empty-state.tsx
@@ -9,22 +9,34 @@ interface EmptyStateProps {
   description: string;
   action?: React.ReactNode;
   className?: string;
+  /** Use "inline" when the EmptyState is already inside a Card */
+  variant?: "card" | "inline";
 }
 
-export function EmptyState({ icon: Icon, title, description, action, className }: EmptyStateProps) {
+export function EmptyState({ icon: Icon, title, description, action, className, variant = "card" }: EmptyStateProps) {
+  const content = (
+    <div className={cn("flex flex-col items-center justify-center py-12 px-6 text-center", variant === "card" && "py-16")}>
+      <div className="w-16 h-16 bg-gray-100 dark:bg-gray-700 rounded-full flex items-center justify-center mb-4">
+        <Icon className="h-8 w-8 text-gray-400 dark:text-gray-500" />
+      </div>
+      <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+        {title}
+      </h3>
+      <p className="text-sm text-gray-500 dark:text-gray-400 max-w-sm mb-6">
+        {description}
+      </p>
+      {action && <div>{action}</div>}
+    </div>
+  );
+
+  if (variant === "inline") {
+    return <div className={className}>{content}</div>;
+  }
+
   return (
     <Card className={cn("bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm border-dashed border-2 border-gray-200 dark:border-gray-700", className)}>
-      <CardContent className="flex flex-col items-center justify-center py-16 px-6 text-center">
-        <div className="w-16 h-16 bg-gray-100 dark:bg-gray-700 rounded-full flex items-center justify-center mb-4">
-          <Icon className="h-8 w-8 text-gray-400 dark:text-gray-500" />
-        </div>
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
-          {title}
-        </h3>
-        <p className="text-sm text-gray-500 dark:text-gray-400 max-w-sm mb-6">
-          {description}
-        </p>
-        {action && <div>{action}</div>}
+      <CardContent>
+        {content}
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## Summary
- Added `variant` prop (`"card"` | `"inline"`) to the reusable `EmptyState` component to support usage inside existing Card wrappers
- Replaced custom inline empty state in the device detail maintenance history section with the shared `EmptyState` component
- All empty states across the app now use the same reusable component for visual consistency

## What changed
- **`empty-state.tsx`**: Extracted inner content into a shared `content` variable; added `variant="inline"` that renders without the Card wrapper
- **`devices/[id]/page.tsx`**: Replaced 10 lines of custom inline empty state with a single `<EmptyState variant="inline" .../>` call

## Test plan
- [ ] Verify empty state renders correctly on the device detail page when no maintenance history exists
- [ ] Verify existing empty states (dashboard, houses list, house detail, maintenance types) still render correctly
- [ ] Verify dark mode styling is consistent across all empty states
- [ ] Build passes (`next build`)

Closes #20

https://claude.ai/code/session_01XeU1hVwE8N6oVsh2CFFrJF