### PR TITLE
Add DashboardSkeleton component for improved loading UX

### DIFF
--- a/src/HouseFlow.Frontend/src/app/[locale]/(dashboard)/dashboard/page.tsx
+++ b/src/HouseFlow.Frontend/src/app/[locale]/(dashboard)/dashboard/page.tsx
@@ -7,7 +7,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Button } from '@/components/ui/button';
 import Link from 'next/link';
 import { useAuth } from '@/lib/auth/context';
-import { HousesGridSkeleton } from '@/components/ui/skeleton';
+import { HousesGridSkeleton, DashboardSkeleton } from '@/components/ui/skeleton';
 import { ScoreRing } from '@/components/ui/score-ring';
 import { Check, Clock, AlertTriangle, Plus, Home, ChevronRight, Wrench, Calendar, Building2 } from 'lucide-react';
 import { EmptyState } from '@/components/ui/empty-state';
@@ -31,6 +31,11 @@ export default function DashboardPage() {
   const totalUpToDate = houses.reduce((acc, h) => acc + (h.score === 100 ? 1 : 0), 0);
   const totalPending = houses.reduce((acc, h) => acc + h.pendingCount, 0);
   const totalOverdue = houses.reduce((acc, h) => acc + h.overdueCount, 0);
+
+  // Show full-page skeleton while initial data is loading
+  if (isLoading && !housesData) {
+    return <DashboardSkeleton />;
+  }
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/30 to-slate-50 dark:from-gray-900 dark:via-gray-900 dark:to-gray-900 p-4 sm:p-8">

--- a/src/HouseFlow.Frontend/src/components/ui/skeleton.tsx
+++ b/src/HouseFlow.Frontend/src/components/ui/skeleton.tsx
@@ -130,6 +130,80 @@ export function HouseDetailSkeleton() {
   );
 }
 
+// Skeleton for dashboard page (hero + upcoming tasks + houses grid)
+export function DashboardSkeleton() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/30 to-slate-50 dark:from-gray-900 dark:via-gray-900 dark:to-gray-900 p-4 sm:p-8">
+      <div className="max-w-7xl mx-auto">
+        {/* Hero section skeleton */}
+        <div className="mb-8 border border-gray-200 dark:border-gray-700 rounded-lg bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm">
+          <div className="p-6 sm:p-8">
+            <div className="flex flex-col lg:flex-row lg:items-center gap-8">
+              {/* Score ring placeholder */}
+              <div className="flex-shrink-0 flex justify-center lg:justify-start">
+                <Skeleton className="hidden sm:block w-40 h-40 rounded-full" />
+                <Skeleton className="sm:hidden w-28 h-28 rounded-full" />
+              </div>
+
+              {/* Welcome text placeholder */}
+              <div className="flex-1 flex flex-col items-center lg:items-start gap-2">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-8 w-64" />
+                <Skeleton className="h-4 w-48" />
+                <div className="flex gap-2 mt-2">
+                  <Skeleton className="h-9 w-28 rounded-full" />
+                  <Skeleton className="h-9 w-28 rounded-full" />
+                </div>
+              </div>
+
+              {/* CTA button placeholder */}
+              <div className="flex-shrink-0 flex justify-center lg:justify-end">
+                <Skeleton className="h-10 w-40 rounded-md" />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Upcoming tasks skeleton */}
+        <div className="mb-8">
+          <div className="flex items-center justify-between mb-4">
+            <Skeleton className="h-7 w-48" />
+            <div className="flex gap-2">
+              <Skeleton className="h-7 w-12 rounded-full" />
+              <Skeleton className="h-7 w-12 rounded-full" />
+            </div>
+          </div>
+          <div className="space-y-3">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="border border-gray-200 dark:border-gray-700 rounded-lg p-4 bg-white/80 dark:bg-gray-800/80 border-l-4 border-l-gray-300 dark:border-l-gray-600">
+                <div className="flex items-center justify-between gap-4">
+                  <div className="flex items-center gap-3 flex-1">
+                    <Skeleton className="w-10 h-10 rounded-lg flex-shrink-0" />
+                    <div className="flex-1">
+                      <Skeleton className="h-5 w-40 mb-1" />
+                      <Skeleton className="h-4 w-56" />
+                    </div>
+                  </div>
+                  <Skeleton className="h-4 w-24 hidden sm:block" />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Houses grid section title */}
+        <div className="flex items-center justify-between mb-6">
+          <Skeleton className="h-7 w-32" />
+          <Skeleton className="h-5 w-20" />
+        </div>
+
+        {/* Houses grid skeleton */}
+        <HousesGridSkeleton />
+      </div>
+    </div>
+  );
+}
+
 // Skeleton for list items (maintenance, devices)
 export function ListItemSkeleton() {
   return (


### PR DESCRIPTION
## Summary
Added a comprehensive skeleton loading component for the dashboard page to provide better visual feedback while initial data is loading.

## Key Changes
- **New `DashboardSkeleton` component**: Created a full-page skeleton that mirrors the dashboard layout, including:
  - Hero section with score ring placeholder and welcome text
  - Upcoming tasks section with 3 skeleton task items
  - Houses grid section with title and grid skeleton
  - Proper responsive design with mobile/desktop variants
  - Dark mode support matching the dashboard styling

- **Updated dashboard page**: Modified `dashboard/page.tsx` to:
  - Import the new `DashboardSkeleton` component
  - Display the skeleton while initial data is loading (`isLoading && !housesData`)
  - Provides immediate visual feedback instead of blank screen during data fetch

## Implementation Details
- The skeleton layout matches the actual dashboard structure with proper spacing and proportions
- Uses existing `Skeleton` and `HousesGridSkeleton` components for consistency
- Includes responsive design considerations (hidden elements on mobile, different sizes for score ring)
- Maintains the same gradient background and styling as the actual dashboard
- Skeleton is only shown during initial load when `housesData` is not yet available

https://claude.ai/code/session_01MYfthvwHCzH7KGqnooryup