### PR TITLE
Pin GitHub Actions sur SHA au lieu de tags mutables

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0 # Need tags for CalVer counter
 
@@ -61,7 +61,7 @@ jobs:
           echo "Version: $TAG"
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -113,14 +113,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Encode compose file
         id: compose
         run: echo "b64=$(base64 -w0 infrastructure/docker-compose.preprod.yaml)" >> "$GITHUB_OUTPUT"
 
       - name: Sync compose and pull images
-        uses: appleboy/ssh-action@v1
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1
         with:
           host: ${{ secrets.DEPLOY_HOST }}
           port: ${{ secrets.DEPLOY_SSH_PORT }}
@@ -146,7 +146,7 @@ jobs:
           COMPOSE_B64: ${{ steps.compose.outputs.b64 }}
 
       - name: Start services
-        uses: appleboy/ssh-action@v1
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1
         with:
           host: ${{ secrets.DEPLOY_HOST }}
           port: ${{ secrets.DEPLOY_SSH_PORT }}
@@ -177,14 +177,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Encode compose file
         id: compose
         run: echo "b64=$(base64 -w0 infrastructure/docker-compose.prod.yaml)" >> "$GITHUB_OUTPUT"
 
       - name: Deploy prod via SSH
-        uses: appleboy/ssh-action@v1
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1
         with:
           host: ${{ secrets.DEPLOY_HOST }}
           port: ${{ secrets.DEPLOY_SSH_PORT }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
         with:
           dotnet-version: '10.0.x'
 
@@ -54,7 +54,7 @@ jobs:
           exit 1
 
       - name: Backend Test Report
-        uses: dorny/test-reporter@v2
+        uses: dorny/test-reporter@df6247429542221bc30d46a036ee47af1102c451 # v2
         if: always()
         with:
           name: Backend Test Results
@@ -62,7 +62,7 @@ jobs:
           reporter: dotnet-trx
 
       - name: Upload Test Results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: backend-test-results
@@ -81,10 +81,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
           cache: 'npm'
@@ -104,7 +104,7 @@ jobs:
         continue-on-error: true
 
       - name: Frontend Unit Test Report
-        uses: dorny/test-reporter@v2
+        uses: dorny/test-reporter@df6247429542221bc30d46a036ee47af1102c451 # v2
         if: always()
         with:
           name: Frontend Unit Test Results
@@ -149,15 +149,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
         with:
           dotnet-version: '10.0.x'
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
           cache: 'npm'
@@ -254,7 +254,7 @@ jobs:
         run: PLAYWRIGHT_JUNIT_OUTPUT_NAME=test-results/e2e-junit.xml npx playwright test --project=chromium --reporter=list,junit
 
       - name: E2E Test Report
-        uses: dorny/test-reporter@v2
+        uses: dorny/test-reporter@df6247429542221bc30d46a036ee47af1102c451 # v2
         if: always()
         with:
           name: E2E Test Results (Playwright)
@@ -262,7 +262,7 @@ jobs:
           reporter: java-junit
 
       - name: Upload Playwright Report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: playwright-report
@@ -270,7 +270,7 @@ jobs:
           retention-days: 30
 
       - name: Upload service logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:
           name: service-logs

--- a/.github/workflows/sync-db.yml
+++ b/.github/workflows/sync-db.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Sync database via SSH
-        uses: appleboy/ssh-action@v1
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1
         with:
           host: ${{ secrets.DEPLOY_HOST }}
           port: ${{ secrets.DEPLOY_SSH_PORT }}


### PR DESCRIPTION
## Summary
- Remplace toutes les références par tag mutable (`@v4`, `@v3`, `@v1`, `@v2`) par des SHA de commit fixes dans les 3 workflows
- Ajoute un commentaire `# vX` après chaque SHA pour conserver la lisibilité
- Protège contre les attaques supply chain (tag hijacking)

### Actions pinnées
| Action | Tag | SHA |
|--------|-----|-----|
| `actions/checkout` | v4 | `34e11487` |
| `docker/login-action` | v3 | `c94ce9fb` |
| `appleboy/ssh-action` | v1 | `0ff4204d` |
| `actions/setup-dotnet` | v4 | `67a3573c` |
| `dorny/test-reporter` | v2 | `df624742` |
| `actions/upload-artifact` | v4 | `ea165f8d` |
| `actions/setup-node` | v4 | `49933ea5` |

### Fichiers modifiés
- `.github/workflows/deploy.yml` (7 actions)
- `.github/workflows/pr.yml` (13 actions)
- `.github/workflows/sync-db.yml` (1 action)

## Mise à jour des SHA
Pour mettre à jour un SHA quand une nouvelle version sort :
```bash
gh api repos/OWNER/REPO/git/ref/tags/vX --jq '.object.sha'
```
Si le type est `tag` (annotated), déréférencer avec :
```bash
gh api repos/OWNER/REPO/git/tags/SHA --jq '.object.sha'
```

## Test plan
- [ ] Vérifier que le workflow `PR Checks` passe sur cette PR
- [ ] Vérifier que les SHAs correspondent bien aux tags attendus

Closes #44

https://claude.ai/code/session_01TG7qnS687LVTYKPdEGFy1h