### PR TITLE
Separate DB migrations from API startup

### DIFF
--- a/PROJECT_KNOWLEDGE.md
+++ b/PROJECT_KNOWLEDGE.md
@@ -1,6 +1,6 @@
 # HouseFlow - Project Knowledge Base
 
-**Last Updated**: 2026-03-17
+**Last Updated**: 2026-03-23
 
 ## Project Overview
 
@@ -379,7 +379,17 @@ npm run test:debug    # Debug mode
 - 70 E2E tests passing
 - Tests use InMemory database (doesn't check migrations)
 
-## Recent Changes (2025-12-25)
+## Recent Changes (2026-03-23)
+
+### Separate DB Migrations from API Startup (#45)
+- Removed auto-migration (`Database.Migrate()`) from API startup
+- Added `--migrate` CLI mode: `dotnet HouseFlow.API.dll --migrate` runs migrations then exits
+- Docker-compose (preprod/prod) now use a `migrate` init container that runs before the API starts
+- API depends on `migrate` with `service_completed_successfully` condition
+- Integration tests (Testing env) still auto-migrate via Program.cs
+- CI E2E tests already used `dotnet ef database update` separately
+
+## Previous Changes (2025-12-25)
 
 ### API-First Workflow Implementation
 1. Updated `openapi.yaml`:

--- a/infrastructure/docker-compose.preprod.yaml
+++ b/infrastructure/docker-compose.preprod.yaml
@@ -1,4 +1,21 @@
 services:
+  migrate:
+    image: ghcr.io/barberouss/houseflow-api:${IMAGE_TAG:-latest}
+    container_name: houseflow-migrate-preprod
+    command: ["dotnet", "HouseFlow.API.dll", "--migrate"]
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Production
+      - ConnectionStrings__houseflow=Host=postgres;Port=5432;Database=houseflow;Username=${DB_USER};Password=${DB_PASSWORD}
+      - JWT__KEY=${JWT_KEY}
+      - Jwt__Issuer=${JWT_ISSUER}
+      - Jwt__Audience=${JWT_AUDIENCE}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - internal
+    restart: "no"
+
   api:
     image: ghcr.io/barberouss/houseflow-api:${IMAGE_TAG:-latest}
     container_name: houseflow-api-preprod
@@ -16,6 +33,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
     networks:
       - internal
       - proxy

--- a/infrastructure/docker-compose.prod.yaml
+++ b/infrastructure/docker-compose.prod.yaml
@@ -1,4 +1,21 @@
 services:
+  migrate:
+    image: ghcr.io/barberouss/houseflow-api:${IMAGE_TAG:-latest}
+    container_name: houseflow-migrate-prod
+    command: ["dotnet", "HouseFlow.API.dll", "--migrate"]
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Production
+      - ConnectionStrings__houseflow=Host=postgres;Port=5432;Database=houseflow;Username=${DB_USER};Password=${DB_PASSWORD}
+      - JWT__KEY=${JWT_KEY}
+      - Jwt__Issuer=${JWT_ISSUER}
+      - Jwt__Audience=${JWT_AUDIENCE}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - internal
+    restart: "no"
+
   api:
     image: ghcr.io/barberouss/houseflow-api:${IMAGE_TAG:-latest}
     container_name: houseflow-api-prod
@@ -16,6 +33,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
     networks:
       - internal
       - proxy

--- a/src/HouseFlow.API/Program.cs
+++ b/src/HouseFlow.API/Program.cs
@@ -239,7 +239,8 @@ if (!builder.Environment.IsDevelopment() && builder.Environment.EnvironmentName 
 
 var app = builder.Build();
 
-// Apply pending migrations automatically
+// --migrate mode: apply migrations and exit (used by init containers / CI)
+if (args.Contains("--migrate"))
 {
     using var scope = app.Services.CreateScope();
     var dbContext = scope.ServiceProvider.GetRequiredService<HouseFlowDbContext>();
@@ -247,7 +248,9 @@ var app = builder.Build();
 
     try
     {
+        logger.LogInformation("Running database migrations...");
         dbContext.Database.Migrate();
+        logger.LogInformation("Database migrations applied successfully.");
     }
     catch (Exception ex)
     {
@@ -255,25 +258,39 @@ var app = builder.Build();
         throw;
     }
 
-    // Seed default admin user (Development only - NOT for production)
-    if (app.Environment.IsDevelopment())
+    return; // Exit after migration — do not start the web server
+}
+
+// Auto-migrate only in Testing environment (integration tests via Testcontainers)
+if (app.Environment.EnvironmentName == "Testing")
+{
+    using var scope = app.Services.CreateScope();
+    var dbContext = scope.ServiceProvider.GetRequiredService<HouseFlowDbContext>();
+    dbContext.Database.Migrate();
+}
+
+// Seed default admin user (Development only - NOT for production)
+if (app.Environment.IsDevelopment())
+{
+    using var scope = app.Services.CreateScope();
+    var dbContext = scope.ServiceProvider.GetRequiredService<HouseFlowDbContext>();
+    var logger = scope.ServiceProvider.GetRequiredService<ILogger<Program>>();
+
+    const string adminEmail = "admin@admin.com";
+    if (!dbContext.Users.Any(u => u.Email == adminEmail))
     {
-        const string adminEmail = "admin@admin.com";
-        if (!dbContext.Users.Any(u => u.Email == adminEmail))
+        var adminUser = new User
         {
-            var adminUser = new User
-            {
-                Id = Guid.NewGuid(),
-                Email = adminEmail,
-                PasswordHash = BCryptNet.HashPassword("admin"),
-                FirstName = "Admin",
-                LastName = "User",
-                CreatedAt = DateTime.UtcNow
-            };
-            dbContext.Users.Add(adminUser);
-            dbContext.SaveChanges();
-            logger.LogInformation("Default admin user created: {Email}", adminEmail);
-        }
+            Id = Guid.NewGuid(),
+            Email = adminEmail,
+            PasswordHash = BCryptNet.HashPassword("admin"),
+            FirstName = "Admin",
+            LastName = "User",
+            CreatedAt = DateTime.UtcNow
+        };
+        dbContext.Users.Add(adminUser);
+        dbContext.SaveChanges();
+        logger.LogInformation("Default admin user created: {Email}", adminEmail);
     }
 }
 


### PR DESCRIPTION
## Summary
- Removed automatic `Database.Migrate()` from API startup — migrations no longer run when the API boots
- Added `--migrate` CLI mode (`dotnet HouseFlow.API.dll --migrate`) that applies migrations then exits
- Added `migrate` init container in docker-compose (preprod + prod) that runs before the API starts, using `service_completed_successfully` dependency
- Integration tests (Testing env) still auto-migrate for convenience; CI E2E already used `dotnet ef database update`

## Test plan
- [x] Unit tests pass (7/7)
- [x] Integration tests pass (144/144) — confirms Testing env auto-migration still works
- [ ] Verify preprod deployment: `migrate` container runs migrations, then API starts
- [ ] Test migration rollback: `dotnet ef database update <previous-migration>` via CLI

Closes #45

https://claude.ai/code/session_0143JJiBG2siDYqQgUH3yXCL