### PR TITLE
fix(ci): prevent E2E tests from being cancelled

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -237,6 +237,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: [backend-unit-tests, backend-integration-tests, frontend-checks]
+    if: ${{ !cancelled() }}
 
     env:
       NEXT_PUBLIC_API_URL: "http://localhost:5203"


### PR DESCRIPTION
## Summary
- Add `if: !cancelled()` to the `e2e-tests` job in `pr.yml` so it runs even when upstream jobs (`backend-unit-tests`, `backend-integration-tests`, `frontend-checks`) fail
- Previously, if any dependency job failed, GitHub Actions automatically cancelled/skipped the E2E job — meaning no E2E results were ever reported

## Root cause
The `e2e-tests` job uses `needs: [backend-unit-tests, backend-integration-tests, frontend-checks]`. By default, GitHub Actions skips dependent jobs when any `needs` job fails. The `cancel-in-progress: true` concurrency setting also cancels E2E when a new push arrives mid-run. The `if: !cancelled()` condition ensures the job runs as long as the workflow itself isn't cancelled.

## Test plan
- [x] Backend tests pass (7 unit + 144 integration)
- [x] Frontend unit tests pass (82 tests)
- [x] Frontend build succeeds
- [x] E2E tests pass locally (37 Playwright tests)
- [ ] CI checks pass on this PR — E2E job should complete (not cancelled)

https://claude.ai/code/session_01EJYZ5aN8HePS1e8f5hvwHG