### PR TITLE
Split Terraform state: isolate prod/preprod from shared infra

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -22,6 +22,7 @@ jobs:
   plan:
     name: Terraform Plan
     runs-on: ubuntu-latest
+    environment: preprod
     timeout-minutes: 15
 
     steps:


### PR DESCRIPTION
## Summary

- **Split Terraform state** into 3 independent states to prevent preprod deploys from touching prod:
  - `main/` → shared infra only (VNet, PostgreSQL, CAE, identity, bastion)
  - `deploy-prod/` → prod Container Apps (`deploy-prod.tfstate`)
  - `deploy-preprod/` → preprod Container Apps (`deploy-preprod.tfstate`)
- **New `infra.yml` workflow** — plan-only on push, apply via manual `workflow_dispatch` with production approval gate
- **Simplified `deploy.yml`** — each job targets its own Terraform dir with simple `api_image_tag`/`frontend_image_tag` variables, no cross-env tag preservation hack
- **Removed obsolete `migrate-state.yml`** workflow
- **Fixed OIDC** — added `environment: preprod` to infra plan job (federated identity is per-environment, not per-branch)
- **Moved management locks** for prod Container Apps to `deploy-prod/`

## Context

Previously, prod and preprod Container Apps shared the same Terraform state (`main.tfstate`). When `deploy-preprod` ran `terraform apply`, it also updated the prod image tag — bypassing the manual approval gate. This split follows the same `terraform_remote_state` pattern already used by `ephemeral/`.

## First deploy procedure

Since the RG was emptied, no state migration is needed:
1. Run `infra.yml` via workflow_dispatch (creates shared infra + populates `main.tfstate` outputs)
2. Run `deploy.yml` (creates Container Apps from scratch in the correct states)

## Test plan

- [x] `dotnet test` — 151 tests passing (7 unit + 144 integration)
- [x] `npx vitest run` — 82 tests passing
- [x] `npx next build` — OK
- [x] `bash scripts/verify-e2e.sh` — 37 E2E tests passing

https://claude.ai/code/session_01Dqfker2xsGBhpk8LVoToTg