### PR TITLE
Fix Terraform variable interpolation in container app startup script

### DIFF
--- a/infrastructure/terraform/deploy-preprod/container-app-api.tf
+++ b/infrastructure/terraform/deploy-preprod/container-app-api.tf
@@ -59,40 +59,40 @@ resource "azurerm_container_app" "api_preprod" {
 
         # Get Entra ID token via managed identity endpoint (auto-injected by Container Apps)
         echo "Acquiring Entra ID token..."
-        RESPONSE=$(wget -q -O- --timeout=10 --header="X-IDENTITY-HEADER: $IDENTITY_HEADER" \
-          "$IDENTITY_ENDPOINT?resource=https%3A%2F%2Fossrdbms-aad.database.windows.net&api-version=2019-08-01&client_id=$AZURE_CLIENT_ID")
-        TOKEN=$(echo "$RESPONSE" | sed 's/.*"access_token":"\([^"]*\)".*/\1/')
-        if [ -z "$TOKEN" ] || [ "$TOKEN" = "$RESPONSE" ]; then
+        RESPONSE=$$(wget -q -O- --timeout=10 --header="X-IDENTITY-HEADER: $$IDENTITY_HEADER" \
+          "$$IDENTITY_ENDPOINT?resource=https%3A%2F%2Fossrdbms-aad.database.windows.net&api-version=2019-08-01&client_id=$$AZURE_CLIENT_ID")
+        TOKEN=$$(echo "$$RESPONSE" | sed 's/.*"access_token":"\([^"]*\)".*/\1/')
+        if [ -z "$$TOKEN" ] || [ "$$TOKEN" = "$$RESPONSE" ]; then
           echo "ERROR: Failed to extract access token from identity endpoint"
           exit 1
         fi
-        export PGPASSWORD="$TOKEN"
+        export PGPASSWORD="$$TOKEN"
         export PGSSLMODE=require
-        echo "Token acquired (${#TOKEN} chars)"
+        echo "Token acquired ($${#TOKEN} chars)"
 
         # Check if prod DB has tables to clone
-        PROD_TABLES=$(psql -h "$PG_HOST" -U "$PG_USER" -d "$PROD_DB" -tAc \
+        PROD_TABLES=$$(psql -h "$$PG_HOST" -U "$$PG_USER" -d "$$PROD_DB" -tAc \
           "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public';")
-        if [ "$PROD_TABLES" -lt 1 ]; then
+        if [ "$$PROD_TABLES" -lt 1 ]; then
           echo "Prod DB has no public tables — skipping clone (migrations will create schema)"
           exit 0
         fi
-        echo "Prod DB has $PROD_TABLES public tables"
+        echo "Prod DB has $$PROD_TABLES public tables"
 
         # Dump prod and restore to preprod (pipefail ensures pg_dump failures propagate)
         echo "Starting pg_dump | psql..."
-        pg_dump -h "$PG_HOST" -U "$PG_USER" -d "$PROD_DB" \
+        pg_dump -h "$$PG_HOST" -U "$$PG_USER" -d "$$PROD_DB" \
           --clean --if-exists --no-owner --no-acl | \
-          psql -h "$PG_HOST" -U "$PG_USER" -d "$PREPROD_DB" -q
+          psql -h "$$PG_HOST" -U "$$PG_USER" -d "$$PREPROD_DB" -q
 
         # Verify clone succeeded
-        PREPROD_TABLES=$(psql -h "$PG_HOST" -U "$PG_USER" -d "$PREPROD_DB" -tAc \
+        PREPROD_TABLES=$$(psql -h "$$PG_HOST" -U "$$PG_USER" -d "$$PREPROD_DB" -tAc \
           "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public';")
-        if [ "$PREPROD_TABLES" -lt 1 ]; then
+        if [ "$$PREPROD_TABLES" -lt 1 ]; then
           echo "ERROR: Preprod DB has no public tables after clone — aborting"
           exit 1
         fi
-        echo "=== Clone complete ($PREPROD_TABLES public tables) ==="
+        echo "=== Clone complete ($$PREPROD_TABLES public tables) ==="
       EOT
       ]
 


### PR DESCRIPTION
## Summary
Fixed Terraform variable interpolation syntax in the Container App API preprod deployment script. The startup script uses shell variable expansion which was conflicting with Terraform's own interpolation syntax, causing variables to be incorrectly evaluated.

## Key Changes
- Escaped all shell variable references by doubling the dollar signs (`$` → `$$`) throughout the startup script
- This ensures Terraform treats these as literal `$` characters in the final shell script, allowing the shell to properly expand variables like `$IDENTITY_HEADER`, `$RESPONSE`, `$TOKEN`, etc.
- Applied consistently across all variable references including:
  - Environment variables (`$$IDENTITY_HEADER`, `$$IDENTITY_ENDPOINT`, `$$AZURE_CLIENT_ID`)
  - Command substitutions (`$$(wget ...)`, `$$(psql ...)`, `$$(echo ...)`)
  - Variable expansions (`$${#TOKEN}`)
  - Conditional checks and string comparisons

## Implementation Details
The startup script performs database cloning from production to preprod using managed identity authentication. The script:
1. Acquires an Entra ID token via the managed identity endpoint
2. Checks if the production database has tables to clone
3. Performs a pg_dump/psql pipeline to clone the schema
4. Verifies the clone succeeded

By properly escaping the dollar signs, Terraform will now correctly pass the shell script with single dollar signs, allowing the shell to perform the necessary variable expansion at runtime.

https://claude.ai/code/session_01Kr6kGV7HFmCjQJvajBPKwG