### PR TITLE
fix(infra): use azapi provider for managed certificates

### DIFF
--- a/infrastructure/terraform/deploy-prod/custom-domains.tf
+++ b/infrastructure/terraform/deploy-prod/custom-domains.tf
@@ -1,31 +1,47 @@
 # ── Managed certificates (free, auto-renewed by Azure) ──
+# AzureRM ~4.0 doesn't support managed certificates natively,
+# so we use azapi to create them via the ARM API.
 
-resource "azurerm_container_app_environment_managed_certificate" "api" {
-  name                         = "cert-api-prod"
-  container_app_environment_id = local.main.container_app_environment_id
-  subject_name                 = var.api_domain_prod
-  domain_control_validation    = "CNAME"
+resource "azapi_resource" "cert_api" {
+  type      = "Microsoft.App/managedEnvironments/managedCertificates@2024-03-01"
+  name      = "cert-api-prod"
+  parent_id = local.main.container_app_environment_id
+  location  = "westeurope"
+
+  body = {
+    properties = {
+      subjectName             = var.api_domain_prod
+      domainControlValidation = "CNAME"
+    }
+  }
 }
 
-resource "azurerm_container_app_environment_managed_certificate" "frontend" {
-  name                         = "cert-frontend-prod"
-  container_app_environment_id = local.main.container_app_environment_id
-  subject_name                 = var.frontend_domain_prod
-  domain_control_validation    = "CNAME"
+resource "azapi_resource" "cert_frontend" {
+  type      = "Microsoft.App/managedEnvironments/managedCertificates@2024-03-01"
+  name      = "cert-frontend-prod"
+  parent_id = local.main.container_app_environment_id
+  location  = "westeurope"
+
+  body = {
+    properties = {
+      subjectName             = var.frontend_domain_prod
+      domainControlValidation = "CNAME"
+    }
+  }
 }
 
 # ── Custom domain bindings ───────────────────────────────
 
 resource "azurerm_container_app_custom_domain" "api" {
-  name                                     = trimprefix(var.api_domain_prod, ".")
+  name                                     = var.api_domain_prod
   container_app_id                         = azurerm_container_app.api_prod.id
-  container_app_environment_certificate_id = azurerm_container_app_environment_managed_certificate.api.id
+  container_app_environment_certificate_id = azapi_resource.cert_api.id
   certificate_binding_type                 = "SniEnabled"
 }
 
 resource "azurerm_container_app_custom_domain" "frontend" {
-  name                                     = trimprefix(var.frontend_domain_prod, ".")
+  name                                     = var.frontend_domain_prod
   container_app_id                         = azurerm_container_app.frontend_prod.id
-  container_app_environment_certificate_id = azurerm_container_app_environment_managed_certificate.frontend.id
+  container_app_environment_certificate_id = azapi_resource.cert_frontend.id
   certificate_binding_type                 = "SniEnabled"
 }

--- a/infrastructure/terraform/deploy-prod/main.tf
+++ b/infrastructure/terraform/deploy-prod/main.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
     }
+    azapi = {
+      source  = "azure/azapi"
+      version = "~> 2.0"
+    }
   }
 
   backend "azurerm" {


### PR DESCRIPTION
AzureRM ~4.0 doesn't support the managed certificate resource type. Switch to azapi provider to create managed certificates via ARM API (Microsoft.App/managedEnvironments/managedCertificates).

https://claude.ai/code/session_01PpEceG6GgvwK6M5ZCy1CgR