### PR TITLE
Make house address optional when creating a house

### DIFF
--- a/src/HouseFlow.Frontend/src/app/[locale]/(dashboard)/houses/new/page.tsx
+++ b/src/HouseFlow.Frontend/src/app/[locale]/(dashboard)/houses/new/page.tsx
@@ -26,7 +26,12 @@ export default function NewHousePage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    createHouseMutation.mutate({ name, address, zipCode, city });
+    createHouseMutation.mutate({
+      name,
+      address: address || undefined,
+      zipCode: zipCode || undefined,
+      city: city || undefined,
+    });
   };
 
   return (
@@ -71,7 +76,6 @@ export default function NewHousePage() {
                   type="text"
                   value={address}
                   onChange={(e) => setAddress(e.target.value)}
-                  required
                   className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white"
                   placeholder="123 Main Street"
                 />
@@ -87,7 +91,6 @@ export default function NewHousePage() {
                     type="text"
                     value={zipCode}
                     onChange={(e) => setZipCode(e.target.value)}
-                    required
                     className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white"
                     placeholder="12345"
                   />
@@ -102,7 +105,6 @@ export default function NewHousePage() {
                     type="text"
                     value={city}
                     onChange={(e) => setCity(e.target.value)}
-                    required
                     className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white"
                     placeholder="Paris"
                   />

--- a/tests/HouseFlow.IntegrationTests/Houses/HousesTests.cs
+++ b/tests/HouseFlow.IntegrationTests/Houses/HousesTests.cs
@@ -102,6 +102,32 @@ public class HousesTests
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
+    [Fact]
+    public async Task CreateHouse_WithOnlyName_ReturnsHouseWithNullAddress()
+    {
+        // Arrange
+        var (client, _) = await CreateAuthenticatedClientAsync();
+        var request = new CreateHouseRequestDto(
+            Name: "Maison Sans Adresse",
+            Address: null,
+            ZipCode: null,
+            City: null
+        );
+
+        // Act
+        var response = await client.PostAsJsonAsync("/api/v1/houses", request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var house = await response.Content.ReadAsJsonAsync<HouseDto>();
+        house.Should().NotBeNull();
+        house!.Name.Should().Be("Maison Sans Adresse");
+        house.Address.Should().BeNull();
+        house.ZipCode.Should().BeNull();
+        house.City.Should().BeNull();
+    }
+
     #endregion
 
     #region Get Houses Tests


### PR DESCRIPTION
## Summary
- Remove `required` attribute from address, zip code, and city fields in the house creation form
- Only the house name remains mandatory
- Convert empty strings to `undefined` before sending to the API to avoid storing blank values

The backend (DTO, entity, database) already treated these fields as optional — this change aligns the frontend form accordingly.

## Test plan
- [x] Frontend unit tests pass (82/82)
- [x] `next build` succeeds
- [ ] Manual: create a house with only a name (no address) — should succeed
- [ ] Manual: create a house with all fields filled — should still work as before

https://claude.ai/code/session_01DADqjoHXGWBcQQbZcnjxc1