### PR TITLE
Clean up Terraform state blob after PR preview destruction

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -191,6 +191,14 @@ jobs:
           TF_VAR_image_tag: "pr-${{ github.event.pull_request.number }}"
         run: terraform destroy -auto-approve
 
+      - name: Delete tfstate blob
+        run: |
+          az storage blob delete \
+            --account-name sthouseflowtfstate \
+            --container-name tfstate \
+            --name "ephemeral-pr-${{ github.event.pull_request.number }}.tfstate" \
+            --auth-mode login || true
+
       - name: Remove preview label
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Added a cleanup step to the PR preview workflow that deletes the Terraform state blob from Azure Storage after the preview environment is destroyed.

## Key Changes
- Added a new workflow step that removes the ephemeral Terraform state file (`ephemeral-pr-{PR_NUMBER}.tfstate`) from the Azure Storage blob container after `terraform destroy` completes
- Uses Azure CLI to delete the blob with `--auth-mode login` for authentication
- Includes error suppression (`|| true`) to prevent workflow failures if the blob doesn't exist

## Implementation Details
- The step runs after the `terraform destroy` command, ensuring the infrastructure is torn down before state cleanup
- The blob name follows the same naming convention as the Terraform state file created during preview environment setup
- Error handling allows the workflow to continue even if the blob deletion fails, preventing false negatives in the cleanup process

https://claude.ai/code/session_012a7c3g5syZTmhDQBY2CAsf