### PR TITLE
Cancel stale pending workflow runs before deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: deploy-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: deploy-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
   REGISTRY: ghcr.io
@@ -16,11 +16,39 @@ permissions:
   id-token: write
   contents: write
   packages: write
+  actions: write
 
 jobs:
+  # ── Job 0: Cancel runs waiting for prod approval ────
+  cancel-stale-pending:
+    name: Cancel Pending Reviews
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Cancel workflow runs waiting for approval
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            const { data: { workflow_runs } } = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'deploy.yml',
+              status: 'waiting',
+            });
+            for (const run of workflow_runs) {
+              if (run.id === context.runId) continue;
+              console.log(`Cancelling run #${run.id} (${run.display_title})`);
+              await github.rest.actions.cancelWorkflowRun({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: run.id,
+              });
+            }
+
   # ── Job 1: Build & Push ──────────────────────────────
   build:
     name: Build & Push Images
+    needs: cancel-stale-pending
     runs-on: ubuntu-latest
     timeout-minutes: 15
     outputs:


### PR DESCRIPTION
## Summary
Added a new workflow job that cancels any pending deployment workflow runs waiting for approval before starting a new build and deployment cycle. This prevents multiple workflow runs from queuing up and waiting for manual approval simultaneously.

## Key Changes
- Added `actions: write` permission to the workflow to enable cancellation of workflow runs
- Created new `cancel-stale-pending` job that:
  - Runs before the `build` job (via `needs` dependency)
  - Queries for any `deploy.yml` workflow runs in `waiting` status
  - Cancels all waiting runs except the current one
  - Uses `actions/github-script` to interact with the GitHub Actions API
- Updated `build` job to depend on `cancel-stale-pending` job completion

## Implementation Details
- The cancellation logic skips the current workflow run (`run.id === context.runId`) to avoid self-cancellation
- Job has a 2-minute timeout to ensure quick execution
- Uses GitHub's REST API to list and cancel workflow runs
- Provides console logging for visibility into which runs are being cancelled

https://claude.ai/code/session_01Nm4XufcSGnqvWv4KWCGyht