### PR TITLE
Add Phase 5 user stories (Coûts, Budget & Documents)

### DIFF
--- a/specs/user-stories.md
+++ b/specs/user-stories.md
@@ -722,9 +722,10 @@ Score = Moyenne des scores de toutes les maisons
 
 **Critères d'acceptation:**
 - Lors de l'ajout d'un appareil, suggestion des entretiens obligatoires (ex: chaudière gaz → entretien annuel obligatoire en France)
-- Base de données initiale: réglementation française (loi, décret, périodicité)
+- Base de données initiale: réglementation francophone (France, Belgique, Suisse)
+- Sélection du pays dans les paramètres utilisateur ou au niveau de la maison
 - Bouton "Ajouter les entretiens suggérés" en un clic
-- Source légale citée pour chaque suggestion
+- Source légale citée pour chaque suggestion (loi, décret, périodicité)
 - Extensible à d'autres pays ultérieurement
 
 **Réf. issue:** #37

--- a/specs/user-stories.md
+++ b/specs/user-stories.md
@@ -583,6 +583,135 @@ Score = Moyenne des scores de toutes les maisons
 
 ---
 
+## Phase 5 - Enrichissement: Coûts, Budget & Documents
+
+### US-200: Dashboard coûts par maison
+**En tant que** propriétaire ou collaborateur RW
+**Je veux** voir un tableau de bord des dépenses de maintenance par maison
+**Afin de** comprendre combien me coûte l'entretien de chaque propriété
+
+**Critères d'acceptation:**
+- Page dédiée `/houses/{id}/budget` accessible depuis le détail maison
+- Résumé: coût total, coût moyen par intervention, nombre d'interventions
+- Graphique d'évolution des coûts par mois (12 derniers mois) et par année
+- Filtre par appareil et par type de maintenance
+- Filtre par période (mois, trimestre, année, personnalisé)
+- Comparaison entre appareils (quel appareil coûte le plus)
+- Les locataires n'ont pas accès à cette page (cohérent avec le masquage des coûts)
+
+**Réf. issue:** #35
+
+---
+
+### US-201: Budget annuel par maison
+**En tant que** propriétaire
+**Je veux** définir un budget annuel de maintenance par maison
+**Afin de** contrôler mes dépenses et être alerté en cas de dépassement
+
+**Critères d'acceptation:**
+- Champ "Budget annuel" configurable par maison (optionnel)
+- Barre de progression du budget consommé (vert < 80%, orange 80-100%, rouge > 100%)
+- Indicateur sur le dashboard maison si un budget est défini
+- Badge d'alerte sur la carte maison du dashboard quand budget > 80%
+- Historique des budgets par année (pour comparaison inter-annuelle)
+
+---
+
+### US-202: Top prestataires
+**En tant que** propriétaire ou collaborateur RW
+**Je veux** voir un classement de mes prestataires
+**Afin de** comparer leurs tarifs et fréquence d'intervention
+
+**Critères d'acceptation:**
+- Section dans la page budget/coûts
+- Liste des prestataires triés par nombre d'interventions ou coût total
+- Pour chaque prestataire: nom, nombre d'interventions, coût total, coût moyen
+- Filtre par maison (vue globale ou par maison)
+- Les locataires n'y ont pas accès
+
+---
+
+### US-203: Prévisionnel des coûts
+**En tant que** propriétaire
+**Je veux** voir une estimation des coûts à venir
+**Afin de** anticiper mes dépenses de maintenance
+
+**Critères d'acceptation:**
+- Calcul basé sur l'historique des interventions par type de maintenance
+- Affichage: "Coût estimé pour les 12 prochains mois: X €"
+- Détail par appareil (ex: "Chaudière gaz — entretien annuel: ~350 €/an")
+- Indication "Pas assez de données" si historique insuffisant (< 2 interventions)
+- Distinction visuelle entre coûts réels et estimés
+
+---
+
+### US-204: Export CSV des dépenses
+**En tant que** propriétaire
+**Je veux** exporter l'historique des dépenses en CSV
+**Afin de** l'intégrer dans ma comptabilité ou le transmettre à mon assureur
+
+**Critères d'acceptation:**
+- Bouton "Exporter CSV" sur la page budget/coûts
+- Colonnes: date, maison, appareil, type d'entretien, prestataire, coût, notes
+- Filtres appliqués à la vue se reflètent dans l'export
+- Encodage UTF-8 avec BOM (compatibilité Excel)
+- Nom de fichier: `houseflow-depenses-{maison}-{date}.csv`
+
+**Réf. issue:** #36 (partiel — la partie PDF est couverte séparément)
+
+---
+
+### US-205: Upload de documents (factures, certificats)
+**En tant que** propriétaire ou collaborateur RW
+**Je veux** joindre des fichiers (photos, factures, certificats) à un entretien ou un appareil
+**Afin de** centraliser toute la documentation de ma maison
+
+**Critères d'acceptation:**
+- Zone d'upload sur la page appareil et sur le formulaire d'entretien
+- Types acceptés: images (jpg, png, webp), PDF, max 10 Mo par fichier
+- Stockage: Azure Blob Storage avec conteneur privé
+- Galerie de documents par appareil avec vignettes
+- Téléchargement d'un document existant
+- Suppression d'un document (propriétaire et collaborateur RW uniquement)
+- Les locataires peuvent voir les documents mais pas en ajouter/supprimer
+
+**Réf. issue:** #34
+
+---
+
+### US-206: Export PDF du carnet d'entretien
+**En tant que** propriétaire
+**Je veux** générer un carnet d'entretien complet en PDF
+**Afin de** le fournir à un acheteur, un assureur ou un gestionnaire
+
+**Critères d'acceptation:**
+- Bouton "Générer le carnet" sur la page maison
+- Le PDF contient: informations maison, liste des appareils, historique complet des entretiens, coûts totaux
+- Mise en page professionnelle avec logo HouseFlow
+- Filtres optionnels: période, appareil
+- Génération côté serveur (QuestPDF ou similaire)
+- Nom de fichier: `carnet-entretien-{maison}-{date}.pdf`
+
+**Réf. issue:** #36 (partiel)
+
+---
+
+### US-207: Suggestions légales par pays/type d'appareil
+**En tant que** utilisateur
+**Je veux** recevoir des suggestions d'entretiens obligatoires selon mon pays et mes appareils
+**Afin de** être en conformité avec la réglementation
+
+**Critères d'acceptation:**
+- Lors de l'ajout d'un appareil, suggestion des entretiens obligatoires (ex: chaudière gaz → entretien annuel obligatoire en France)
+- Base de données initiale: réglementation française (loi, décret, périodicité)
+- Bouton "Ajouter les entretiens suggérés" en un clic
+- Source légale citée pour chaque suggestion
+- Extensible à d'autres pays ultérieurement
+
+**Réf. issue:** #37
+
+---
+
 ## Résumé
 
 | Module | Stories | Phase |
@@ -602,9 +731,12 @@ Score = Moyenne des scores de toutes les maisons
 | Rôles & permissions | US-110, US-111 | Phase 2 |
 | Gestion membres | US-120 à US-123 | Phase 2 |
 | Dashboard partagé | US-130 | Phase 2 |
+| Coûts & Budget | US-200, US-201, US-202, US-203, US-204 | Phase 5 |
+| Documents & Export | US-205, US-206 | Phase 5 |
+| Suggestions légales | US-207 | Phase 5 |
 
-**Total: 34 user stories (25 MVP + 9 Phase 2)**
+**Total: 42 user stories (25 MVP + 9 Phase 2 + 8 Phase 5)**
 
 ---
 
-**Dernière mise à jour:** 2026-03-17
+**Dernière mise à jour:** 2026-03-31


### PR DESCRIPTION
## Summary
- Ajoute 8 user stories Phase 5 (US-200 à US-207) dans `specs/user-stories.md`
- Couvre le tableau de bord coûts, budget annuel, classement prestataires, prévisionnel, export CSV, upload documents, export PDF, suggestions légales
- Met à jour le tableau résumé (34 → 42 user stories)

## Issues GitHub liées
Les issues suivantes ont été créées/enrichies dans le milestone "Phase 5: Enrichissement" :
- #35 — Dashboard coûts & statistiques (enrichie, US-200)
- #114 — Budget annuel par maison (nouvelle, US-201)
- #115 — Top prestataires (nouvelle, US-202)
- #116 — Prévisionnel des coûts (nouvelle, US-203)
- #117 — Export CSV des dépenses (nouvelle, US-204)
- #34 — Upload documents (labellisée, US-205)
- #36 — Export PDF carnet d'entretien (labellisée, US-206)
- #37 — Suggestions légales (labellisée, US-207)

## Test plan
- [ ] Vérifier que le fichier `specs/user-stories.md` est bien formaté et cohérent
- [ ] Vérifier que les numéros US-200 à US-207 ne conflictent pas avec d'autres stories
- [ ] Vérifier que le tableau résumé est à jour (42 stories)

https://claude.ai/code/session_015QWkRBH6B8Pco5W7z4ANGj