### PR TITLE
feat: comprehensive error boundaries with per-section handling and logging

### DIFF
--- a/src/HouseFlow.Frontend/src/app/[locale]/(auth)/error.tsx
+++ b/src/HouseFlow.Frontend/src/app/[locale]/(auth)/error.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { useTranslations } from "next-intl";
+import { logClientError } from "@/lib/error-logger";
+
+export default function AuthError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const t = useTranslations("errors");
+
+  useEffect(() => {
+    logClientError(error, "route-error", { digest: error.digest });
+  }, [error]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-8">
+      <Card className="max-w-md w-full bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm">
+        <CardContent className="p-8 text-center">
+          <div className="w-16 h-16 bg-red-100 dark:bg-red-900/30 rounded-full flex items-center justify-center mx-auto mb-4">
+            <AlertTriangle className="h-8 w-8 text-red-600 dark:text-red-400" />
+          </div>
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+            {t("somethingWentWrong")}
+          </h3>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">
+            {t("authError")}
+          </p>
+          <Button
+            onClick={reset}
+            className="bg-gradient-to-r from-blue-500 to-blue-600 hover:from-blue-600 hover:to-blue-700"
+          >
+            {t("tryAgain")}
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/HouseFlow.Frontend/src/app/[locale]/(auth)/layout.tsx
+++ b/src/HouseFlow.Frontend/src/app/[locale]/(auth)/layout.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { useLocale } from 'next-intl';
 import { useAuth } from '@/lib/auth/context';
 import { consumeFormRedirecting } from '@/lib/auth/redirect-guard';
+import { ErrorBoundary } from '@/components/ui/error-boundary';
 
 export default function AuthLayout({ children }: { children: React.ReactNode }) {
   const { isAuthenticated, isLoading } = useAuth();
@@ -28,5 +29,9 @@ export default function AuthLayout({ children }: { children: React.ReactNode }) 
     return null;
   }
 
-  return <>{children}</>;
+  return (
+    <ErrorBoundary>
+      {children}
+    </ErrorBoundary>
+  );
 }

--- a/src/HouseFlow.Frontend/src/app/[locale]/(dashboard)/error.tsx
+++ b/src/HouseFlow.Frontend/src/app/[locale]/(dashboard)/error.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { useTranslations } from "next-intl";
+import { logClientError } from "@/lib/error-logger";
+
+export default function DashboardError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const t = useTranslations("errors");
+
+  useEffect(() => {
+    logClientError(error, "route-error", { digest: error.digest });
+  }, [error]);
+
+  return (
+    <div className="min-h-[60vh] flex items-center justify-center p-8">
+      <Card className="max-w-md w-full bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm">
+        <CardContent className="p-8 text-center">
+          <div className="w-16 h-16 bg-red-100 dark:bg-red-900/30 rounded-full flex items-center justify-center mx-auto mb-4">
+            <AlertTriangle className="h-8 w-8 text-red-600 dark:text-red-400" />
+          </div>
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+            {t("somethingWentWrong")}
+          </h3>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">
+            {t("dashboardError")}
+          </p>
+          <Button
+            onClick={reset}
+            className="bg-gradient-to-r from-blue-500 to-blue-600 hover:from-blue-600 hover:to-blue-700"
+          >
+            {t("tryAgain")}
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/HouseFlow.Frontend/src/app/[locale]/not-found.tsx
+++ b/src/HouseFlow.Frontend/src/app/[locale]/not-found.tsx
@@ -1,0 +1,28 @@
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+
+export default function LocaleNotFound() {
+  const t = useTranslations("errors");
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 p-8">
+      <div className="text-center max-w-md">
+        <p className="text-7xl font-bold text-gray-200 dark:text-gray-700 mb-2">
+          404
+        </p>
+        <h1 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
+          {t("notFoundTitle")}
+        </h1>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mb-8">
+          {t("notFoundDescription")}
+        </p>
+        <Link
+          href="/"
+          className="inline-block rounded-lg bg-gradient-to-r from-blue-500 to-blue-600 px-6 py-2.5 text-sm font-medium text-white hover:from-blue-600 hover:to-blue-700 transition-all"
+        >
+          {t("backToHome")}
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/HouseFlow.Frontend/src/app/global-error.tsx
+++ b/src/HouseFlow.Frontend/src/app/global-error.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useEffect } from "react";
+import { logClientError } from "@/lib/error-logger";
+
+/**
+ * Root-level error boundary. This catches errors that bubble past every
+ * other error.tsx in the tree, including failures in the root layout itself.
+ *
+ * Because the root layout (and therefore all providers / i18n) may be broken,
+ * this page deliberately uses no external UI components or translations.
+ */
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    logClientError(error, "global-error", { digest: error.digest });
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body
+        style={{
+          margin: 0,
+          fontFamily:
+            '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          minHeight: "100vh",
+          backgroundColor: "#f9fafb",
+          color: "#111827",
+        }}
+      >
+        <div style={{ textAlign: "center", maxWidth: 420, padding: 32 }}>
+          <div
+            style={{
+              width: 64,
+              height: 64,
+              borderRadius: "50%",
+              backgroundColor: "#fee2e2",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              margin: "0 auto 16px",
+              fontSize: 28,
+            }}
+          >
+            ⚠
+          </div>
+          <h1 style={{ fontSize: 20, fontWeight: 600, marginBottom: 8 }}>
+            Something went wrong
+          </h1>
+          <p style={{ fontSize: 14, color: "#6b7280", marginBottom: 24 }}>
+            An unexpected error occurred. Please try again.
+          </p>
+          <button
+            onClick={reset}
+            style={{
+              padding: "10px 24px",
+              fontSize: 14,
+              fontWeight: 500,
+              color: "#fff",
+              backgroundColor: "#3b82f6",
+              border: "none",
+              borderRadius: 8,
+              cursor: "pointer",
+            }}
+          >
+            Try again
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/src/HouseFlow.Frontend/src/app/not-found.tsx
+++ b/src/HouseFlow.Frontend/src/app/not-found.tsx
@@ -1,0 +1,61 @@
+import Link from "next/link";
+
+/**
+ * Root-level 404 page. Shown when no locale segment matches either.
+ * Uses no i18n since we're outside the locale layout.
+ */
+export default function RootNotFound() {
+  return (
+    <html lang="en">
+      <body
+        style={{
+          margin: 0,
+          fontFamily:
+            '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          minHeight: "100vh",
+          backgroundColor: "#f9fafb",
+          color: "#111827",
+        }}
+      >
+        <div style={{ textAlign: "center", maxWidth: 420, padding: 32 }}>
+          <p
+            style={{
+              fontSize: 64,
+              fontWeight: 700,
+              color: "#d1d5db",
+              margin: "0 0 8px",
+              lineHeight: 1,
+            }}
+          >
+            404
+          </p>
+          <h1 style={{ fontSize: 20, fontWeight: 600, marginBottom: 8 }}>
+            Page not found
+          </h1>
+          <p style={{ fontSize: 14, color: "#6b7280", marginBottom: 24 }}>
+            The page you are looking for does not exist or has been moved.
+          </p>
+          <Link
+            href="/"
+            style={{
+              display: "inline-block",
+              padding: "10px 24px",
+              fontSize: 14,
+              fontWeight: 500,
+              color: "#fff",
+              backgroundColor: "#3b82f6",
+              border: "none",
+              borderRadius: 8,
+              textDecoration: "none",
+            }}
+          >
+            Go home
+          </Link>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/src/HouseFlow.Frontend/src/components/ui/error-boundary.tsx
+++ b/src/HouseFlow.Frontend/src/components/ui/error-boundary.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { Component, type ReactNode } from "react";
+import { Component, type ErrorInfo, type ReactNode } from "react";
 import { AlertTriangle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { useTranslations } from "next-intl";
+import { logClientError } from "@/lib/error-logger";
 
 interface ErrorBoundaryClassProps {
   children: ReactNode;
@@ -14,6 +15,7 @@ interface ErrorBoundaryClassProps {
     unexpectedError: string;
     tryAgain: string;
   };
+  onReset?: () => void;
 }
 
 interface ErrorBoundaryState {
@@ -28,6 +30,12 @@ class ErrorBoundaryClass extends Component<ErrorBoundaryClassProps, ErrorBoundar
 
   static getDerivedStateFromError(): ErrorBoundaryState {
     return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    logClientError(error, "error-boundary", {
+      componentStack: info.componentStack,
+    });
   }
 
   render() {
@@ -52,7 +60,10 @@ class ErrorBoundaryClass extends Component<ErrorBoundaryClassProps, ErrorBoundar
                 {translations?.unexpectedError ?? "An unexpected error occurred. Please try again."}
               </p>
               <Button
-                onClick={() => this.setState({ hasError: false })}
+                onClick={() => {
+                  this.setState({ hasError: false });
+                  this.props.onReset?.();
+                }}
                 className="bg-gradient-to-r from-blue-500 to-blue-600 hover:from-blue-600 hover:to-blue-700"
               >
                 {translations?.tryAgain ?? "Try again"}
@@ -70,14 +81,16 @@ class ErrorBoundaryClass extends Component<ErrorBoundaryClassProps, ErrorBoundar
 interface ErrorBoundaryProps {
   children: ReactNode;
   fallback?: ReactNode;
+  onReset?: () => void;
 }
 
-export function ErrorBoundary({ children, fallback }: ErrorBoundaryProps) {
+export function ErrorBoundary({ children, fallback, onReset }: ErrorBoundaryProps) {
   const t = useTranslations("common");
 
   return (
     <ErrorBoundaryClass
       fallback={fallback}
+      onReset={onReset}
       translations={{
         somethingWentWrong: t("somethingWentWrong"),
         unexpectedError: t("unexpectedError"),

--- a/src/HouseFlow.Frontend/src/lib/error-logger.ts
+++ b/src/HouseFlow.Frontend/src/lib/error-logger.ts
@@ -1,0 +1,74 @@
+/**
+ * Centralized client-side error logger.
+ *
+ * All UI errors (error boundaries, unhandled rejections, Next.js error pages)
+ * should flow through this module so we have a single place to hook in a
+ * remote error-tracking service (Sentry, LogRocket, …) later.
+ */
+
+export interface ErrorLogEntry {
+  message: string;
+  source: "error-boundary" | "global-error" | "route-error" | "unhandled";
+  componentStack?: string | null;
+  digest?: string;
+  url?: string;
+  timestamp: string;
+}
+
+const MAX_LOG_SIZE = 50;
+const STORAGE_KEY = "houseflow_error_log";
+
+function getStoredLog(): ErrorLogEntry[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as ErrorLogEntry[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function persistLog(entries: ErrorLogEntry[]) {
+  if (typeof window === "undefined") return;
+  try {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+  } catch {
+    // sessionStorage full – silently drop
+  }
+}
+
+/**
+ * Log a client-side error. Currently persists to sessionStorage and
+ * console.error. Replace the body with a fetch() call when a remote
+ * error-tracking endpoint is available.
+ */
+export function logClientError(
+  error: unknown,
+  source: ErrorLogEntry["source"],
+  extra?: { componentStack?: string | null; digest?: string },
+) {
+  const entry: ErrorLogEntry = {
+    message: error instanceof Error ? error.message : String(error),
+    source,
+    componentStack: extra?.componentStack ?? null,
+    digest: extra?.digest,
+    url: typeof window !== "undefined" ? window.location.href : undefined,
+    timestamp: new Date().toISOString(),
+  };
+
+  // Console (always)
+  console.error(`[${source}]`, error, extra);
+
+  // Session-persistent ring buffer
+  const log = getStoredLog();
+  log.push(entry);
+  if (log.length > MAX_LOG_SIZE) log.splice(0, log.length - MAX_LOG_SIZE);
+  persistLog(log);
+}
+
+/**
+ * Read the in-session error log (useful for debugging / support forms).
+ */
+export function getClientErrorLog(): ErrorLogEntry[] {
+  return getStoredLog();
+}

--- a/src/HouseFlow.Frontend/src/messages/en.json
+++ b/src/HouseFlow.Frontend/src/messages/en.json
@@ -208,6 +208,19 @@
     "registerToAccept": "Create an account to accept this invitation",
     "error": "Failed to accept invitation"
   },
+  "errors": {
+    "somethingWentWrong": "Something went wrong",
+    "tryAgain": "Try again",
+    "backToHome": "Back to home",
+    "notFoundTitle": "Page not found",
+    "notFoundDescription": "The page you are looking for does not exist or has been moved.",
+    "forbiddenTitle": "Access denied",
+    "forbiddenDescription": "You do not have permission to access this page.",
+    "serverErrorTitle": "Server error",
+    "serverErrorDescription": "An internal error occurred. Our team has been notified.",
+    "dashboardError": "An error occurred while loading this section. Please try again.",
+    "authError": "An error occurred during authentication. Please try again."
+  },
   "upcomingTasks": {
     "title": "Upcoming Tasks",
     "noTasks": "No pending tasks",

--- a/src/HouseFlow.Frontend/src/messages/fr.json
+++ b/src/HouseFlow.Frontend/src/messages/fr.json
@@ -208,6 +208,19 @@
     "registerToAccept": "Créez un compte pour accepter cette invitation",
     "error": "Impossible d'accepter l'invitation"
   },
+  "errors": {
+    "somethingWentWrong": "Une erreur est survenue",
+    "tryAgain": "Réessayer",
+    "backToHome": "Retour à l'accueil",
+    "notFoundTitle": "Page introuvable",
+    "notFoundDescription": "La page que vous recherchez n'existe pas ou a été déplacée.",
+    "forbiddenTitle": "Accès refusé",
+    "forbiddenDescription": "Vous n'avez pas la permission d'accéder à cette page.",
+    "serverErrorTitle": "Erreur serveur",
+    "serverErrorDescription": "Une erreur interne est survenue. Notre équipe a été notifiée.",
+    "dashboardError": "Une erreur est survenue lors du chargement de cette section. Veuillez réessayer.",
+    "authError": "Une erreur est survenue lors de l'authentification. Veuillez réessayer."
+  },
   "upcomingTasks": {
     "title": "Tâches à venir",
     "noTasks": "Aucune tâche en attente",


### PR DESCRIPTION
Closes #43

- Add centralized error logger (sessionStorage ring buffer, ready for
  remote tracking integration)
- Enhance ErrorBoundary with componentDidCatch logging and onReset callback
- Add global-error.tsx as root-level catch-all (500)
- Add not-found.tsx at root and locale level (404)
- Add error.tsx per route group (dashboard, auth) with contextual retry
- Wrap auth layout in ErrorBoundary
- Add errors i18n namespace (en/fr) for all error pages

https://claude.ai/code/session_015w1Xk8GgUPfhEPiMMmEFmc