### PR TITLE
feat: implement optimistic UI updates for mutations

### DIFF
--- a/src/HouseFlow.Frontend/src/lib/api/hooks/__tests__/devices.test.ts
+++ b/src/HouseFlow.Frontend/src/lib/api/hooks/__tests__/devices.test.ts
@@ -1,7 +1,15 @@
+import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { createWrapper } from '@/__tests__/test-utils';
 import { useDevices, useDevice, useCreateDevice, useUpdateDevice, useDeleteDevice } from '../devices';
+
+function createWrapperWith(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
 
 vi.mock('../../client', () => ({
   default: {
@@ -95,6 +103,57 @@ describe('useCreateDevice', () => {
     expect(result.current.data).toEqual(newDevice);
     expect(mockedClient.post).toHaveBeenCalledWith('/api/v1/houses/h1/devices', { name: 'VMC', type: 'VMC' });
   });
+
+  it('optimistically adds device to cache and invalidates on success', async () => {
+    const existingDevices = [
+      { id: 'd1', name: 'Chaudière', type: 'Chaudière Gaz', score: 100, pendingCount: 0, overdueCount: 0 },
+    ];
+    const newDevice = { id: 'd2', name: 'VMC', type: 'VMC', houseId: 'h1', createdAt: '2024-01-01' };
+    mockedClient.post.mockResolvedValueOnce({ data: newDevice });
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: Infinity }, mutations: { retry: false } },
+    });
+    queryClient.setQueryData(['houses', 'h1', 'devices'], existingDevices);
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    const wrapper = createWrapperWith(queryClient);
+
+    const { result } = renderHook(() => useCreateDevice('h1'), { wrapper });
+
+    result.current.mutate({ name: 'VMC', type: 'VMC' });
+
+    // Optimistic update should add the device immediately
+    await waitFor(() => {
+      const data = queryClient.getQueryData<{ name: string }[]>(['houses', 'h1', 'devices']);
+      expect(data).toHaveLength(2);
+      expect(data?.[1]?.name).toBe('VMC');
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['houses', 'h1', 'devices'], refetchType: 'active' });
+  });
+
+  it('rolls back optimistic update on error', async () => {
+    const existingDevices = [
+      { id: 'd1', name: 'Chaudière', type: 'Chaudière Gaz', score: 100, pendingCount: 0, overdueCount: 0 },
+    ];
+    mockedClient.post.mockRejectedValueOnce(new Error('Server error'));
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: Infinity }, mutations: { retry: false } },
+    });
+    queryClient.setQueryData(['houses', 'h1', 'devices'], existingDevices);
+    const wrapper = createWrapperWith(queryClient);
+
+    const { result } = renderHook(() => useCreateDevice('h1'), { wrapper });
+
+    result.current.mutate({ name: 'VMC', type: 'VMC' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    const data = queryClient.getQueryData(['houses', 'h1', 'devices']);
+    expect(data).toEqual(existingDevices);
+  });
 });
 
 describe('useUpdateDevice', () => {
@@ -132,5 +191,56 @@ describe('useDeleteDevice', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(mockedClient.delete).toHaveBeenCalledWith('/api/v1/devices/d1');
+  });
+
+  it('optimistically removes device from cache and invalidates on success', async () => {
+    const existingDevices = [
+      { id: 'd1', name: 'Chaudière', type: 'Chaudière Gaz', score: 100, pendingCount: 0, overdueCount: 0 },
+      { id: 'd2', name: 'VMC', type: 'VMC', score: 90, pendingCount: 1, overdueCount: 0 },
+    ];
+    mockedClient.delete.mockResolvedValueOnce({});
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: Infinity }, mutations: { retry: false } },
+    });
+    queryClient.setQueryData(['houses', 'h1', 'devices'], existingDevices);
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    const wrapper = createWrapperWith(queryClient);
+
+    const { result } = renderHook(() => useDeleteDevice(), { wrapper });
+
+    result.current.mutate({ deviceId: 'd1', houseId: 'h1' });
+
+    // Optimistic update should remove the device immediately
+    await waitFor(() => {
+      const data = queryClient.getQueryData<{ id: string }[]>(['houses', 'h1', 'devices']);
+      expect(data).toHaveLength(1);
+      expect(data?.[0]?.id).toBe('d2');
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['houses', 'h1', 'devices'], refetchType: 'active' });
+  });
+
+  it('rolls back optimistic update on error', async () => {
+    const existingDevices = [
+      { id: 'd1', name: 'Chaudière', type: 'Chaudière Gaz', score: 100, pendingCount: 0, overdueCount: 0 },
+    ];
+    mockedClient.delete.mockRejectedValueOnce(new Error('Server error'));
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: Infinity }, mutations: { retry: false } },
+    });
+    queryClient.setQueryData(['houses', 'h1', 'devices'], existingDevices);
+    const wrapper = createWrapperWith(queryClient);
+
+    const { result } = renderHook(() => useDeleteDevice(), { wrapper });
+
+    result.current.mutate({ deviceId: 'd1', houseId: 'h1' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    const data = queryClient.getQueryData(['houses', 'h1', 'devices']);
+    expect(data).toEqual(existingDevices);
   });
 });

--- a/src/HouseFlow.Frontend/src/lib/api/hooks/__tests__/houses.test.ts
+++ b/src/HouseFlow.Frontend/src/lib/api/hooks/__tests__/houses.test.ts
@@ -107,23 +107,58 @@ describe('useCreateHouse', () => {
     expect(mockedClient.post).toHaveBeenCalledWith('/api/v1/houses', { name: 'Appartement' });
   });
 
-  it('invalidates cache and calls onSuccess when both are provided', async () => {
+  it('optimistically adds house to cache and invalidates on success', async () => {
+    const existingData = {
+      houses: [{ id: '1', name: 'Maison', score: 85, devicesCount: 3, pendingCount: 1, overdueCount: 0 }],
+      globalScore: 85,
+    };
     const newHouse = { id: '2', name: 'Appartement' };
     mockedClient.post.mockResolvedValueOnce({ data: newHouse });
-    const onSuccess = vi.fn();
 
-    const queryClient = createTestQueryClient();
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: Infinity }, mutations: { retry: false } },
+    });
+    queryClient.setQueryData(['houses'], existingData);
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
     const wrapper = createWrapperWith(queryClient);
 
-    const { result } = renderHook(() => useCreateHouse({ onSuccess }), { wrapper });
+    const { result } = renderHook(() => useCreateHouse(), { wrapper });
 
     result.current.mutate({ name: 'Appartement' });
 
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    // Optimistic update should add the house immediately
+    await waitFor(() => {
+      const data = queryClient.getQueryData<{ houses: { name: string }[] }>(['houses']);
+      expect(data?.houses).toHaveLength(2);
+      expect(data?.houses[1]?.name).toBe('Appartement');
+    });
 
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['houses'], refetchType: 'active' });
-    expect(onSuccess).toHaveBeenCalled();
+  });
+
+  it('rolls back optimistic update on error', async () => {
+    const existingData = {
+      houses: [{ id: '1', name: 'Maison', score: 85, devicesCount: 3, pendingCount: 1, overdueCount: 0 }],
+      globalScore: 85,
+    };
+    mockedClient.post.mockRejectedValueOnce(new Error('Server error'));
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: Infinity }, mutations: { retry: false } },
+    });
+    queryClient.setQueryData(['houses'], existingData);
+    const wrapper = createWrapperWith(queryClient);
+
+    const { result } = renderHook(() => useCreateHouse(), { wrapper });
+
+    result.current.mutate({ name: 'Appartement' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    // Cache should be rolled back to original data
+    const data = queryClient.getQueryData(['houses']);
+    expect(data).toEqual(existingData);
   });
 });
 
@@ -184,21 +219,61 @@ describe('useDeleteHouse', () => {
     expect(mockedClient.delete).toHaveBeenCalledWith('/api/v1/houses/1');
   });
 
-  it('invalidates cache and calls onSuccess when both are provided', async () => {
+  it('optimistically removes house from cache and invalidates on success', async () => {
+    const existingData = {
+      houses: [
+        { id: '1', name: 'Maison', score: 85, devicesCount: 3, pendingCount: 1, overdueCount: 0 },
+        { id: '2', name: 'Appartement', score: 90, devicesCount: 1, pendingCount: 0, overdueCount: 0 },
+      ],
+      globalScore: 87,
+    };
     mockedClient.delete.mockResolvedValueOnce({});
-    const onSuccess = vi.fn();
 
-    const queryClient = createTestQueryClient();
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: Infinity }, mutations: { retry: false } },
+    });
+    queryClient.setQueryData(['houses'], existingData);
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
     const wrapper = createWrapperWith(queryClient);
 
-    const { result } = renderHook(() => useDeleteHouse({ onSuccess }), { wrapper });
+    const { result } = renderHook(() => useDeleteHouse(), { wrapper });
 
     result.current.mutate('1');
 
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    // Optimistic update should remove the house immediately
+    await waitFor(() => {
+      const data = queryClient.getQueryData<{ houses: { id: string }[] }>(['houses']);
+      expect(data?.houses).toHaveLength(1);
+      expect(data?.houses[0]?.id).toBe('2');
+    });
 
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['houses'], refetchType: 'active' });
-    expect(onSuccess).toHaveBeenCalled();
+  });
+
+  it('rolls back optimistic update on error', async () => {
+    const existingData = {
+      houses: [
+        { id: '1', name: 'Maison', score: 85, devicesCount: 3, pendingCount: 1, overdueCount: 0 },
+      ],
+      globalScore: 85,
+    };
+    mockedClient.delete.mockRejectedValueOnce(new Error('Server error'));
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: Infinity }, mutations: { retry: false } },
+    });
+    queryClient.setQueryData(['houses'], existingData);
+    const wrapper = createWrapperWith(queryClient);
+
+    const { result } = renderHook(() => useDeleteHouse(), { wrapper });
+
+    result.current.mutate('1');
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    // Cache should be rolled back to original data
+    const data = queryClient.getQueryData(['houses']);
+    expect(data).toEqual(existingData);
   });
 });

--- a/src/HouseFlow.Frontend/src/lib/api/hooks/__tests__/maintenance.test.ts
+++ b/src/HouseFlow.Frontend/src/lib/api/hooks/__tests__/maintenance.test.ts
@@ -1,5 +1,7 @@
+import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { createWrapper } from '@/__tests__/test-utils';
 import {
   useMaintenanceTypes,
@@ -8,6 +10,12 @@ import {
   useUpcomingTasks,
   useLogMaintenance,
 } from '../maintenance';
+
+function createWrapperWith(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
 
 vi.mock('../../client', () => ({
   default: {
@@ -188,5 +196,103 @@ describe('useLogMaintenance', () => {
       date: '2024-12-01T00:00:00Z',
       cost: 200,
     });
+  });
+
+  it('optimistically updates maintenance type status and upcoming tasks', async () => {
+    const maintenanceTypes = [
+      {
+        id: 'mt1',
+        name: 'Révision',
+        periodicity: 'Annual',
+        deviceId: 'd1',
+        createdAt: '2024-01-01',
+        status: 'overdue',
+        lastMaintenanceDate: '2023-06-01',
+        nextDueDate: '2024-06-01',
+      },
+    ];
+    const upcomingTasks = {
+      tasks: [
+        {
+          maintenanceTypeId: 'mt1',
+          maintenanceTypeName: 'Révision',
+          deviceId: 'd1',
+          deviceName: 'Chaudière',
+          deviceType: 'Chaudière Gaz',
+          houseId: 'h1',
+          houseName: 'Maison',
+          status: 'overdue' as const,
+          nextDueDate: '2024-06-01',
+          periodicity: 'Annual',
+        },
+      ],
+      overdueCount: 1,
+      pendingCount: 0,
+    };
+    const logged = {
+      id: 'mi2',
+      date: '2024-12-01T00:00:00Z',
+      cost: 200,
+      maintenanceTypeId: 'mt1',
+      maintenanceTypeName: 'Révision',
+      createdAt: '2024-12-01',
+    };
+    mockedClient.post.mockResolvedValueOnce({ data: logged });
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: Infinity }, mutations: { retry: false } },
+    });
+    queryClient.setQueryData(['devices', 'd1', 'maintenance-types'], maintenanceTypes);
+    queryClient.setQueryData(['upcoming-tasks', undefined], upcomingTasks);
+    const wrapper = createWrapperWith(queryClient);
+
+    const { result } = renderHook(() => useLogMaintenance('mt1'), { wrapper });
+
+    result.current.mutate({ date: '2024-12-01T00:00:00Z', cost: 200 });
+
+    // Optimistic update should change status to up_to_date
+    await waitFor(() => {
+      const types = queryClient.getQueryData<{ status: string }[]>(['devices', 'd1', 'maintenance-types']);
+      expect(types?.[0]?.status).toBe('up_to_date');
+    });
+
+    // Upcoming tasks should have the task removed
+    const tasks = queryClient.getQueryData<{ tasks: unknown[]; overdueCount: number }>(['upcoming-tasks', undefined]);
+    expect(tasks?.tasks).toHaveLength(0);
+    expect(tasks?.overdueCount).toBe(0);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+
+  it('rolls back optimistic update on error', async () => {
+    const maintenanceTypes = [
+      {
+        id: 'mt1',
+        name: 'Révision',
+        periodicity: 'Annual',
+        deviceId: 'd1',
+        createdAt: '2024-01-01',
+        status: 'overdue',
+        lastMaintenanceDate: '2023-06-01',
+        nextDueDate: '2024-06-01',
+      },
+    ];
+    mockedClient.post.mockRejectedValueOnce(new Error('Server error'));
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: Infinity }, mutations: { retry: false } },
+    });
+    queryClient.setQueryData(['devices', 'd1', 'maintenance-types'], maintenanceTypes);
+    const wrapper = createWrapperWith(queryClient);
+
+    const { result } = renderHook(() => useLogMaintenance('mt1'), { wrapper });
+
+    result.current.mutate({ date: '2024-12-01T00:00:00Z', cost: 200 });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    // Cache should be rolled back
+    const types = queryClient.getQueryData(['devices', 'd1', 'maintenance-types']);
+    expect(types).toEqual(maintenanceTypes);
   });
 });

--- a/src/HouseFlow.Frontend/src/lib/api/hooks/devices.ts
+++ b/src/HouseFlow.Frontend/src/lib/api/hooks/devices.ts
@@ -109,31 +109,56 @@ export function useDevice(
 }
 
 /**
- * Hook to create a new device
+ * Hook to create a new device (with optimistic update)
  */
 export function useCreateDevice(
   houseId: string,
   options?: UseMutationOptions<DeviceDto, Error, CreateDeviceRequestDto>
 ) {
   const queryClient = useQueryClient();
-
   return useMutation({
     mutationFn: async (data: CreateDeviceRequestDto) => {
       const response = await apiClient.post<DeviceDto>(`/api/v1/houses/${houseId}/devices`, data);
       return response.data;
     },
-    onSuccess: async () => {
-      // Force refetch and wait for it to complete
-      await queryClient.invalidateQueries({
-        queryKey: ['houses', houseId, 'devices'],
-        refetchType: 'active'
-      });
-      await queryClient.invalidateQueries({
-        queryKey: ['houses', houseId],
-        refetchType: 'active'
-      });
+    onMutate: async (newDevice) => {
+      await queryClient.cancelQueries({ queryKey: ['houses', houseId, 'devices'] });
+      const previousDevices = queryClient.getQueryData<DeviceSummaryDto[]>(['houses', houseId, 'devices']);
+
+      if (previousDevices) {
+        const optimisticDevice: DeviceSummaryDto = {
+          id: `temp-${Date.now()}`,
+          name: newDevice.name,
+          type: newDevice.type,
+          brand: newDevice.brand,
+          model: newDevice.model,
+          installDate: newDevice.installDate,
+          score: 100,
+          pendingCount: 0,
+          overdueCount: 0,
+        };
+        queryClient.setQueryData<DeviceSummaryDto[]>(
+          ['houses', houseId, 'devices'],
+          [...previousDevices, optimisticDevice]
+        );
+      }
+
+      return { previousDevices };
     },
-    ...options,
+    onSuccess: (...args) => {
+      options?.onSuccess?.(...args);
+    },
+    onError: (...args) => {
+      const context = args[2];
+      if (context?.previousDevices) {
+        queryClient.setQueryData(['houses', houseId, 'devices'], context.previousDevices);
+      }
+      options?.onError?.(...args);
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({ queryKey: ['houses', houseId, 'devices'], refetchType: 'active' });
+      await queryClient.invalidateQueries({ queryKey: ['houses', houseId], refetchType: 'active' });
+    },
   });
 }
 
@@ -162,27 +187,42 @@ export function useUpdateDevice(
 }
 
 /**
- * Hook to delete a device
+ * Hook to delete a device (with optimistic update)
  */
 export function useDeleteDevice(
   options?: UseMutationOptions<void, Error, { deviceId: string; houseId: string }>
 ) {
   const queryClient = useQueryClient();
-
   return useMutation({
-    mutationFn: async ({ deviceId }) => {
+    mutationFn: async ({ deviceId }: { deviceId: string; houseId: string }) => {
       await apiClient.delete(`/api/v1/devices/${deviceId}`);
     },
-    onSuccess: async (_, { houseId }) => {
-      await queryClient.invalidateQueries({
-        queryKey: ['houses', houseId, 'devices'],
-        refetchType: 'active'
-      });
-      await queryClient.invalidateQueries({
-        queryKey: ['houses', houseId],
-        refetchType: 'active'
-      });
+    onMutate: async ({ deviceId, houseId }) => {
+      await queryClient.cancelQueries({ queryKey: ['houses', houseId, 'devices'] });
+      const previousDevices = queryClient.getQueryData<DeviceSummaryDto[]>(['houses', houseId, 'devices']);
+
+      if (previousDevices) {
+        queryClient.setQueryData<DeviceSummaryDto[]>(
+          ['houses', houseId, 'devices'],
+          previousDevices.filter((d) => d.id !== deviceId)
+        );
+      }
+
+      return { previousDevices, houseId };
     },
-    ...options,
+    onSuccess: (...args) => {
+      options?.onSuccess?.(...args);
+    },
+    onError: (...args) => {
+      const context = args[2];
+      if (context?.previousDevices) {
+        queryClient.setQueryData(['houses', context.houseId, 'devices'], context.previousDevices);
+      }
+      options?.onError?.(...args);
+    },
+    onSettled: async (_data, _err, variables) => {
+      await queryClient.invalidateQueries({ queryKey: ['houses', variables.houseId, 'devices'], refetchType: 'active' });
+      await queryClient.invalidateQueries({ queryKey: ['houses', variables.houseId], refetchType: 'active' });
+    },
   });
 }

--- a/src/HouseFlow.Frontend/src/lib/api/hooks/houses.ts
+++ b/src/HouseFlow.Frontend/src/lib/api/hooks/houses.ts
@@ -91,27 +91,55 @@ export function useHouse(houseId: string, options?: UseQueryOptions<HouseDetailD
 }
 
 /**
- * Hook to create a new house
+ * Hook to create a new house (with optimistic update)
  */
 export function useCreateHouse(
   options?: UseMutationOptions<HouseDto, Error, CreateHouseRequestDto>
 ) {
   const queryClient = useQueryClient();
-  const { onSuccess, ...restOptions } = options || {};
-
   return useMutation({
     mutationFn: async (data: CreateHouseRequestDto) => {
       const response = await apiClient.post<HouseDto>('/api/v1/houses', data);
       return response.data;
     },
-    onSuccess: (data, variables, onMutateResult, context) => {
-      queryClient.invalidateQueries({
-        queryKey: ['houses'],
-        refetchType: 'active'
-      });
-      onSuccess?.(data, variables, onMutateResult, context);
+    onMutate: async (newHouse) => {
+      await queryClient.cancelQueries({ queryKey: ['houses'] });
+      const previousData = queryClient.getQueryData<HousesListResponseDto>(['houses']);
+
+      if (previousData) {
+        const optimisticHouse: HouseSummaryDto = {
+          id: `temp-${Date.now()}`,
+          name: newHouse.name,
+          address: newHouse.address,
+          zipCode: newHouse.zipCode,
+          city: newHouse.city,
+          score: 100,
+          devicesCount: 0,
+          pendingCount: 0,
+          overdueCount: 0,
+        };
+        queryClient.setQueryData<HousesListResponseDto>(['houses'], {
+          ...previousData,
+          houses: [...previousData.houses, optimisticHouse],
+        });
+      }
+
+      return { previousData };
     },
-    ...restOptions,
+    onSuccess: (...args) => {
+      options?.onSuccess?.(...args);
+    },
+    onError: (...args) => {
+      const context = args[2];
+      if (context?.previousData) {
+        queryClient.setQueryData(['houses'], context.previousData);
+      }
+      options?.onError?.(...args);
+    },
+    onSettled: (...args) => {
+      queryClient.invalidateQueries({ queryKey: ['houses'], refetchType: 'active' });
+      options?.onSettled?.(...args);
+    },
   });
 }
 
@@ -146,25 +174,42 @@ export function useUpdateHouse(
 }
 
 /**
- * Hook to delete a house
+ * Hook to delete a house (with optimistic update)
  */
 export function useDeleteHouse(
   options?: UseMutationOptions<void, Error, string>
 ) {
   const queryClient = useQueryClient();
-  const { onSuccess, ...restOptions } = options || {};
-
   return useMutation({
     mutationFn: async (houseId: string) => {
       await apiClient.delete(`/api/v1/houses/${houseId}`);
     },
-    onSuccess: (data, variables, onMutateResult, context) => {
-      queryClient.invalidateQueries({
-        queryKey: ['houses'],
-        refetchType: 'active'
-      });
-      onSuccess?.(data, variables, onMutateResult, context);
+    onMutate: async (houseId) => {
+      await queryClient.cancelQueries({ queryKey: ['houses'] });
+      const previousData = queryClient.getQueryData<HousesListResponseDto>(['houses']);
+
+      if (previousData) {
+        queryClient.setQueryData<HousesListResponseDto>(['houses'], {
+          ...previousData,
+          houses: previousData.houses.filter((h) => h.id !== houseId),
+        });
+      }
+
+      return { previousData };
     },
-    ...restOptions,
+    onSuccess: (...args) => {
+      options?.onSuccess?.(...args);
+    },
+    onError: (...args) => {
+      const context = args[2];
+      if (context?.previousData) {
+        queryClient.setQueryData(['houses'], context.previousData);
+      }
+      options?.onError?.(...args);
+    },
+    onSettled: (...args) => {
+      queryClient.invalidateQueries({ queryKey: ['houses'], refetchType: 'active' });
+      options?.onSettled?.(...args);
+    },
   });
 }

--- a/src/HouseFlow.Frontend/src/lib/api/hooks/maintenance.ts
+++ b/src/HouseFlow.Frontend/src/lib/api/hooks/maintenance.ts
@@ -220,14 +220,13 @@ export function useUpcomingTasks(
 }
 
 /**
- * Hook to log a maintenance instance
+ * Hook to log a maintenance instance (with optimistic update)
  */
 export function useLogMaintenance(
   maintenanceTypeId: string,
   options?: UseMutationOptions<MaintenanceInstanceDto, Error, LogMaintenanceRequestDto>
 ) {
   const queryClient = useQueryClient();
-
   return useMutation({
     mutationFn: async (data: LogMaintenanceRequestDto) => {
       const response = await apiClient.post<MaintenanceInstanceDto>(
@@ -236,23 +235,70 @@ export function useLogMaintenance(
       );
       return response.data;
     },
-    ...options,
-    onSuccess: async (data, variables, onMutateResult, context) => {
-      // First invalidate queries and wait for refetch
-      await queryClient.invalidateQueries({
+    onMutate: async (newLog) => {
+      await queryClient.cancelQueries({ queryKey: ['devices'] });
+      await queryClient.cancelQueries({ queryKey: ['upcoming-tasks'] });
+
+      // Snapshot all device queries that contain this maintenance type
+      const deviceQueries = queryClient.getQueriesData<MaintenanceTypeWithStatusDto[]>({
         queryKey: ['devices'],
-        refetchType: 'active'
+        exact: false,
       });
-      await queryClient.invalidateQueries({
-        queryKey: ['houses'],
-        refetchType: 'active'
-      });
-      await queryClient.invalidateQueries({
+
+      // Optimistically update the maintenance type status to up_to_date
+      for (const [queryKey, data] of deviceQueries) {
+        if (!Array.isArray(data)) continue;
+        const hasType = data.some((mt) => mt.id === maintenanceTypeId);
+        if (hasType) {
+          queryClient.setQueryData<MaintenanceTypeWithStatusDto[]>(
+            queryKey,
+            data.map((mt) =>
+              mt.id === maintenanceTypeId
+                ? { ...mt, status: 'up_to_date' as const, lastMaintenanceDate: newLog.date }
+                : mt
+            )
+          );
+        }
+      }
+
+      // Optimistically remove the task from upcoming-tasks
+      const upcomingQueries = queryClient.getQueriesData<UpcomingTasksResponseDto>({
         queryKey: ['upcoming-tasks'],
-        refetchType: 'active'
+        exact: false,
       });
-      // Then call user's onSuccess if provided
-      await options?.onSuccess?.(data, variables, onMutateResult, context);
+      for (const [queryKey, data] of upcomingQueries) {
+        if (!data) continue;
+        const filteredTasks = data.tasks.filter((t) => t.maintenanceTypeId !== maintenanceTypeId);
+        queryClient.setQueryData<UpcomingTasksResponseDto>(queryKey, {
+          tasks: filteredTasks,
+          overdueCount: filteredTasks.filter((t) => t.status === 'overdue').length,
+          pendingCount: filteredTasks.filter((t) => t.status === 'pending').length,
+        });
+      }
+
+      return { deviceQueries, upcomingQueries };
+    },
+    onSuccess: (...args) => {
+      options?.onSuccess?.(...args);
+    },
+    onError: (...args) => {
+      const context = args[2];
+      if (context?.deviceQueries) {
+        for (const [queryKey, data] of context.deviceQueries) {
+          queryClient.setQueryData(queryKey, data);
+        }
+      }
+      if (context?.upcomingQueries) {
+        for (const [queryKey, data] of context.upcomingQueries) {
+          queryClient.setQueryData(queryKey, data);
+        }
+      }
+      options?.onError?.(...args);
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({ queryKey: ['devices'], refetchType: 'active' });
+      await queryClient.invalidateQueries({ queryKey: ['houses'], refetchType: 'active' });
+      await queryClient.invalidateQueries({ queryKey: ['upcoming-tasks'], refetchType: 'active' });
     },
   });
 }


### PR DESCRIPTION
Add optimistic updates for create/delete houses, create/delete devices,
and log maintenance to improve perceived responsiveness. On error, data
is automatically rolled back to the previous state.

Closes #41

https://claude.ai/code/session_012fQuDuzFZocmTt4pEb4nhW