### PR TITLE
Replace loading text with skeleton loader on houses list page

### DIFF
--- a/PROJECT_KNOWLEDGE.md
+++ b/PROJECT_KNOWLEDGE.md
@@ -1,6 +1,6 @@
 # HouseFlow - Project Knowledge Base
 
-**Last Updated**: 2026-03-29
+**Last Updated**: 2026-03-31
 
 ## Project Overview
 
@@ -245,6 +245,31 @@ const { theme, setTheme } = useTheme();
 setTheme('dark'); // 'light' | 'dark' | 'system'
 ```
 
+## Loading UX (Skeleton Loaders)
+
+All pages use skeleton loaders instead of "Loading..." text for better perceived performance.
+
+**Skeleton Components** (`src/HouseFlow.Frontend/src/components/ui/skeleton.tsx`):
+- `Skeleton` — Base animated placeholder (Tailwind `animate-pulse`)
+- `CardSkeleton` — House/device cards
+- `HousesGridSkeleton` — 3-column grid for houses list
+- `HouseDetailSkeleton` — House detail page (breadcrumb, header, device list)
+- `DeviceDetailSkeleton` — Device detail page (header, maintenance types, history)
+- `DashboardSkeleton` — Dashboard (hero, upcoming tasks, houses grid)
+- `ListItemSkeleton` — Maintenance/device list items
+
+**Loading Spinner** (`src/HouseFlow.Frontend/src/components/ui/loading-spinner.tsx`):
+- `LoadingSpinner` — Animated spinner (sm/md/lg)
+- `LoadingState` — Spinner with optional text label
+
+**Usage pattern** (TanStack Query):
+```tsx
+const { data, isLoading } = useHouses();
+if (isLoading) return <HousesGridSkeleton />;
+```
+
+**Button loading states** use `tCommon('loading')` text while `isPending` (forms, dialogs).
+
 ## Running the Application
 
 ### Prerequisites
@@ -299,6 +324,13 @@ npm run test:debug    # Debug mode
 - Backend: 151 tests passing (7 unit + 144 integration)
 - Frontend unit: 82 tests passing
 - Frontend E2E: 37 tests passing
+
+## Recent Changes (2026-03-31)
+
+### Loading Skeletons (#40)
+- Replaced last remaining "Loading..." text (houses list page) with `HousesGridSkeleton`
+- All pages now use skeleton loaders: dashboard, house detail, device detail, houses list
+- Documented skeleton component inventory and usage patterns in PROJECT_KNOWLEDGE.md
 
 ## Recent Changes (2026-03-29)
 
@@ -551,7 +583,7 @@ src/HouseFlow.Frontend/src/
 │   ├── (dashboard)/      # Protected dashboard pages
 │   └── layout.tsx        # Root layout with providers
 ├── components/
-│   ├── ui/               # Shadcn/ui components
+│   ├── ui/               # Shadcn/ui components (incl. skeleton loaders)
 │   ├── providers/        # React context providers
 │   └── ...               # Feature components
 ├── lib/
@@ -633,7 +665,7 @@ NEXT_PUBLIC_API_URL=http://localhost:5203
 1. Set up backend code generation from OpenAPI (currently manual)
 2. Add more comprehensive error handling
 3. Implement retry logic for API calls
-4. Add loading skeletons instead of "Loading..." text
+4. ~~Add loading skeletons instead of "Loading..." text~~ ✅ Done (issue #40)
 5. Implement optimistic UI updates
 
 ## Contact & Resources

--- a/src/HouseFlow.Frontend/src/app/[locale]/(dashboard)/houses/page.tsx
+++ b/src/HouseFlow.Frontend/src/app/[locale]/(dashboard)/houses/page.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
 import Link from 'next/link';
 import { Building2, Plus } from 'lucide-react';
+import { HousesGridSkeleton } from '@/components/ui/skeleton';
 
 export default function HousesPage() {
   const t = useTranslations('houses');
@@ -17,7 +18,7 @@ export default function HousesPage() {
   const houses = housesData?.houses || [];
 
   if (isLoading) {
-    return <div className="p-4 sm:p-8">{tCommon('loading')}</div>;
+    return <div className="p-4 sm:p-8"><HousesGridSkeleton /></div>;
   }
 
   return (


### PR DESCRIPTION
## Summary
Replaced the last remaining "Loading..." text placeholder on the houses list page with a proper skeleton loader component (`HousesGridSkeleton`), completing the loading UX improvements across all pages.

## Changes
- **Houses List Page**: Replaced generic loading text with `HousesGridSkeleton` component for better perceived performance
- **Documentation**: Added comprehensive "Loading UX (Skeleton Loaders)" section to PROJECT_KNOWLEDGE.md documenting:
  - All available skeleton components and their purposes
  - Loading spinner component variants
  - Usage patterns with TanStack Query
  - Button loading state conventions
- **Project Knowledge**: Updated last modified date and marked skeleton implementation task as complete in the roadmap

## Implementation Details
- The `HousesGridSkeleton` component provides a 3-column grid layout that matches the actual houses grid, giving users a better visual preview of incoming content
- This completes the skeleton loader implementation across all pages: dashboard, house detail, device detail, and houses list
- All loading states now follow the consistent pattern of using skeleton loaders instead of text placeholders

https://claude.ai/code/session_019gRJJUBWXvuGmjXqn1vfjw