### PR TITLE
Add automatic API retry with exponential backoff and UI indicator

### DIFF
--- a/PROJECT_KNOWLEDGE.md
+++ b/PROJECT_KNOWLEDGE.md
@@ -1,6 +1,6 @@
 # HouseFlow - Project Knowledge Base
 
-**Last Updated**: 2026-03-29
+**Last Updated**: 2026-03-31
 
 ## Project Overview
 
@@ -299,6 +299,16 @@ npm run test:debug    # Debug mode
 - Backend: 151 tests passing (7 unit + 144 integration)
 - Frontend unit: 82 tests passing
 - Frontend E2E: 37 tests passing
+
+## Recent Changes (2026-03-31)
+
+### API Retry Logic (#42)
+1. **Axios interceptor** (`src/lib/api/client.ts`): Exponential backoff (100ms→200ms→400ms) with ±25% jitter, max 3 attempts
+2. **Idempotent methods only**: GET, PUT, DELETE, HEAD, OPTIONS are retried; POST/PATCH are not (non-idempotent)
+3. **Retryable errors**: 5xx, network errors, timeouts. 4xx errors are never retried
+4. **UI indicator** (`components/ui/retry-indicator.tsx`): Amber banner with spinner shown during retries
+5. **React Query**: Disabled built-in retry (handled at Axios level to avoid double-retrying)
+6. **State tracking**: `onRetryStateChange` listener pattern + `useRetryState` hook for UI binding
 
 ## Recent Changes (2026-03-29)
 

--- a/specs/user-stories.md
+++ b/specs/user-stories.md
@@ -583,6 +583,25 @@ Score = Moyenne des scores de toutes les maisons
 
 ---
 
+## Tech Debt - Résilience réseau
+
+### US-140: Retry automatique des appels API
+**En tant que** utilisateur
+**Je veux** que les appels API échoués soient automatiquement retentés
+**Afin de** ne pas perdre mes actions à cause d'une instabilité réseau
+
+**Critères d'acceptation:**
+- [ ] Retry automatique avec exponential backoff (100ms → 200ms → 400ms) + jitter
+- [ ] Maximum 3 tentatives avant échec définitif
+- [ ] Seules les erreurs retryables sont retentées : 5xx, erreurs réseau, timeouts
+- [ ] Les erreurs client (4xx) ne sont PAS retentées
+- [ ] Les requêtes en écriture (POST, PATCH) ne sont PAS retentées (risque de doublon)
+- [ ] Les requêtes idempotentes (GET, PUT, DELETE) sont retentées
+- [ ] Indicateur visuel discret quand un retry est en cours
+- [ ] L'indicateur disparaît automatiquement après succès ou échec définitif
+
+---
+
 ## Résumé
 
 | Module | Stories | Phase |
@@ -602,9 +621,10 @@ Score = Moyenne des scores de toutes les maisons
 | Rôles & permissions | US-110, US-111 | Phase 2 |
 | Gestion membres | US-120 à US-123 | Phase 2 |
 | Dashboard partagé | US-130 | Phase 2 |
+| Résilience réseau | US-140 | Tech Debt |
 
-**Total: 34 user stories (25 MVP + 9 Phase 2)**
+**Total: 35 user stories (25 MVP + 9 Phase 2 + 1 Tech Debt)**
 
 ---
 
-**Dernière mise à jour:** 2026-03-17
+**Dernière mise à jour:** 2026-03-31

--- a/src/HouseFlow.Frontend/src/app/[locale]/layout.tsx
+++ b/src/HouseFlow.Frontend/src/app/[locale]/layout.tsx
@@ -6,6 +6,7 @@ import { locales } from '@/lib/i18n/config';
 import { ThemeProvider } from '@/components/providers/theme-provider';
 import { QueryProvider } from '@/components/providers/query-provider';
 import { AuthProvider } from '@/lib/auth/context';
+import { RetryIndicator } from '@/components/ui/retry-indicator';
 import "../globals.css";
 
 export default async function LocaleLayout({
@@ -58,6 +59,7 @@ export default async function LocaleLayout({
             <QueryProvider>
               <AuthProvider>
                 {children}
+                <RetryIndicator />
               </AuthProvider>
             </QueryProvider>
           </ThemeProvider>

--- a/src/HouseFlow.Frontend/src/components/providers/query-provider.tsx
+++ b/src/HouseFlow.Frontend/src/components/providers/query-provider.tsx
@@ -17,8 +17,9 @@ export function QueryProvider({ children }: { children: React.ReactNode }) {
             // Cache data for 10 minutes (garbage collection time)
             gcTime: 10 * 60 * 1000, // 10 minutes
 
-            // Retry failed requests only once
-            retry: 1,
+            // Retry handled by Axios interceptor (exponential backoff)
+            // Disable React Query retry to avoid double-retrying
+            retry: false,
 
             // Don't refetch on window focus - reduces unnecessary API calls
             refetchOnWindowFocus: false,

--- a/src/HouseFlow.Frontend/src/components/ui/__tests__/retry-indicator.test.tsx
+++ b/src/HouseFlow.Frontend/src/components/ui/__tests__/retry-indicator.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+// Track the listener that the component registers
+let registeredListener: ((retrying: boolean) => void) | null = null;
+
+vi.mock('@/lib/api/hooks/use-retry-state', () => {
+  const { useState, useEffect } = require('react');
+
+  return {
+    useRetryState: () => {
+      const [isRetrying, setIsRetrying] = useState(false);
+      useEffect(() => {
+        registeredListener = setIsRetrying;
+        return () => { registeredListener = null; };
+      }, []);
+      return isRetrying;
+    },
+  };
+});
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => {
+    const translations: Record<string, string> = {
+      retrying: 'Reconnexion en cours…',
+    };
+    return translations[key] || key;
+  },
+}));
+
+import { RetryIndicator } from '../retry-indicator';
+
+describe('RetryIndicator', () => {
+  beforeEach(() => {
+    registeredListener = null;
+  });
+
+  it('renders with role="status" for accessibility', () => {
+    render(<RetryIndicator />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('is hidden when not retrying', () => {
+    render(<RetryIndicator />);
+    const indicator = screen.getByRole('status');
+    expect(indicator).toHaveClass('opacity-0');
+    expect(indicator).toHaveClass('pointer-events-none');
+  });
+
+  it('becomes visible when retrying', () => {
+    render(<RetryIndicator />);
+
+    act(() => {
+      registeredListener?.(true);
+    });
+
+    const indicator = screen.getByRole('status');
+    expect(indicator).toHaveClass('opacity-100');
+    expect(indicator).not.toHaveClass('pointer-events-none');
+  });
+
+  it('displays the retrying text', () => {
+    render(<RetryIndicator />);
+
+    act(() => {
+      registeredListener?.(true);
+    });
+
+    expect(screen.getByText('Reconnexion en cours…')).toBeInTheDocument();
+  });
+
+  it('hides when retry completes', () => {
+    render(<RetryIndicator />);
+
+    act(() => {
+      registeredListener?.(true);
+    });
+
+    act(() => {
+      registeredListener?.(false);
+    });
+
+    const indicator = screen.getByRole('status');
+    expect(indicator).toHaveClass('opacity-0');
+  });
+});

--- a/src/HouseFlow.Frontend/src/components/ui/retry-indicator.tsx
+++ b/src/HouseFlow.Frontend/src/components/ui/retry-indicator.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils';
+import { useRetryState } from '@/lib/api/hooks/use-retry-state';
+
+export function RetryIndicator() {
+  const isRetrying = useRetryState();
+  const t = useTranslations('common');
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={cn(
+        'fixed bottom-4 left-1/2 -translate-x-1/2 z-50',
+        'flex items-center gap-2 rounded-full bg-amber-100 dark:bg-amber-900 px-4 py-2 shadow-lg',
+        'text-sm text-amber-800 dark:text-amber-200',
+        'transition-all duration-300',
+        isRetrying
+          ? 'translate-y-0 opacity-100'
+          : 'translate-y-4 opacity-0 pointer-events-none',
+      )}
+    >
+      <div className="h-3 w-3 animate-spin rounded-full border-2 border-solid border-amber-600 border-r-transparent" />
+      <span>{t('retrying')}</span>
+    </div>
+  );
+}

--- a/src/HouseFlow.Frontend/src/lib/api/__tests__/retry.test.ts
+++ b/src/HouseFlow.Frontend/src/lib/api/__tests__/retry.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// vi.mock is hoisted, so we cannot reference variables declared above.
+// Instead, we use vi.hoisted to create mock values before hoisting.
+const { mockAxiosInstance, mockInterceptorsResponse, mockInterceptorsRequest } = vi.hoisted(() => {
+  const mockInterceptorsResponse = { use: vi.fn() };
+  const mockInterceptorsRequest = { use: vi.fn() };
+
+  const mockAxiosInstance = vi.fn();
+  (mockAxiosInstance as any).interceptors = {
+    request: mockInterceptorsRequest,
+    response: mockInterceptorsResponse,
+  };
+  (mockAxiosInstance as any).defaults = { headers: { common: {} } };
+
+  return { mockAxiosInstance, mockInterceptorsResponse, mockInterceptorsRequest };
+});
+
+vi.mock('axios', () => ({
+  default: {
+    create: vi.fn(() => mockAxiosInstance),
+    post: vi.fn(),
+  },
+  AxiosError: class extends Error {
+    response: any;
+    config: any;
+    code?: string;
+    constructor(message?: string, code?: string, config?: any, request?: any, response?: any) {
+      super(message);
+      this.code = code;
+      this.config = config;
+      this.response = response;
+    }
+    isAxiosError = true;
+  },
+  AxiosHeaders: class {
+    private headers: Record<string, string> = {};
+    set(key: string, value: string) { this.headers[key] = value; }
+    get(key: string) { return this.headers[key]; }
+  },
+}));
+
+// Import after mocking
+import { onRetryStateChange } from '../client';
+
+describe('Retry logic - module setup', () => {
+  it('registers a response interceptor', () => {
+    expect(mockInterceptorsResponse.use).toHaveBeenCalledTimes(1);
+    const [successHandler, errorHandler] = mockInterceptorsResponse.use.mock.calls[0];
+    expect(typeof successHandler).toBe('function');
+    expect(typeof errorHandler).toBe('function');
+  });
+
+  it('registers a request interceptor', () => {
+    expect(mockInterceptorsRequest.use).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('onRetryStateChange', () => {
+  it('is exported as a function', () => {
+    expect(typeof onRetryStateChange).toBe('function');
+  });
+
+  it('returns an unsubscribe function', () => {
+    const listener = vi.fn();
+    const unsubscribe = onRetryStateChange(listener);
+    expect(typeof unsubscribe).toBe('function');
+    unsubscribe();
+  });
+
+  it('unsubscribe removes the listener', () => {
+    const listener = vi.fn();
+    const unsubscribe = onRetryStateChange(listener);
+    unsubscribe();
+
+    // Subscribing and unsubscribing should not throw
+    const listener2 = vi.fn();
+    const unsub2 = onRetryStateChange(listener2);
+    unsub2();
+  });
+});
+
+describe('Response interceptor error handler', () => {
+  let errorHandler: (error: any) => Promise<any>;
+
+  beforeEach(() => {
+    errorHandler = mockInterceptorsResponse.use.mock.calls[0][1];
+  });
+
+  it('rejects 4xx errors without retrying', async () => {
+    const error = {
+      response: { status: 400, data: { error: 'Bad Request' } },
+      config: { method: 'get', url: '/api/test', headers: {} },
+      isAxiosError: true,
+    };
+
+    await expect(errorHandler(error)).rejects.toBeDefined();
+  });
+
+  it('rejects non-retryable methods (POST) even for 5xx errors', async () => {
+    const error = {
+      response: { status: 500, data: {} },
+      config: { method: 'post', url: '/api/test', headers: {} },
+      isAxiosError: true,
+    };
+
+    await expect(errorHandler(error)).rejects.toBeDefined();
+  });
+
+  it('rejects 401 errors for auth endpoints', async () => {
+    const error = {
+      response: { status: 401, data: {} },
+      config: { method: 'get', url: '/api/v1/auth/login', headers: {}, _retry: false },
+      isAxiosError: true,
+    };
+
+    await expect(errorHandler(error)).rejects.toBeDefined();
+  });
+
+  it('attempts retry for GET on 5xx errors', async () => {
+    const error = {
+      response: { status: 503, data: {} },
+      config: { method: 'get', url: '/api/test', headers: {} },
+      isAxiosError: true,
+    };
+
+    // The retry will call apiClient (mockAxiosInstance), which we can make succeed
+    mockAxiosInstance.mockResolvedValueOnce({ data: 'ok', status: 200 });
+
+    const result = await errorHandler(error);
+    expect(result).toEqual({ data: 'ok', status: 200 });
+    expect(mockAxiosInstance).toHaveBeenCalled();
+  });
+
+  it('attempts retry for DELETE on network errors', async () => {
+    const error = {
+      response: undefined, // network error = no response
+      config: { method: 'delete', url: '/api/test', headers: {} },
+      isAxiosError: true,
+    };
+
+    mockAxiosInstance.mockResolvedValueOnce({ data: 'deleted', status: 204 });
+
+    const result = await errorHandler(error);
+    expect(result).toEqual({ data: 'deleted', status: 204 });
+  });
+
+  it('notifies retry listeners during retry', async () => {
+    const listener = vi.fn();
+    const unsubscribe = onRetryStateChange(listener);
+
+    const error = {
+      response: { status: 500, data: {} },
+      config: { method: 'get', url: '/api/test', headers: {} },
+      isAxiosError: true,
+    };
+
+    mockAxiosInstance.mockResolvedValueOnce({ data: 'ok', status: 200 });
+
+    await errorHandler(error);
+
+    // Listener should have been called with true (retrying) and then false (done)
+    expect(listener).toHaveBeenCalledWith(true);
+    expect(listener).toHaveBeenCalledWith(false);
+
+    unsubscribe();
+  });
+
+  it('stops retrying after max attempts', async () => {
+    const error = {
+      response: { status: 500, data: {} },
+      config: { method: 'get', url: '/api/test', headers: {}, _retryCount: 3 },
+      isAxiosError: true,
+    };
+
+    // Already at max retries, should reject immediately
+    await expect(errorHandler(error)).rejects.toBeDefined();
+  });
+});

--- a/src/HouseFlow.Frontend/src/lib/api/client.ts
+++ b/src/HouseFlow.Frontend/src/lib/api/client.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosError, InternalAxiosRequestConfig } from 'axios';
+import axios, { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
 
 declare global {
   interface Window {
@@ -111,6 +111,87 @@ async function refreshAccessToken(): Promise<string | null> {
   }
 }
 
+// --- Retry configuration ---
+const RETRY_MAX_ATTEMPTS = 3;
+const RETRY_INITIAL_DELAY_MS = 100;
+const RETRY_MAX_DELAY_MS = 2000;
+
+// Methods safe to retry (idempotent)
+const RETRYABLE_METHODS = new Set(['get', 'put', 'delete', 'head', 'options']);
+
+// Retry state tracking for UI indicator
+type RetryListener = (retrying: boolean) => void;
+let retryListeners: RetryListener[] = [];
+let activeRetries = 0;
+
+export function onRetryStateChange(listener: RetryListener): () => void {
+  retryListeners.push(listener);
+  return () => {
+    retryListeners = retryListeners.filter(l => l !== listener);
+  };
+}
+
+function setRetrying(active: boolean) {
+  activeRetries += active ? 1 : -1;
+  activeRetries = Math.max(0, activeRetries);
+  retryListeners.forEach(l => l(activeRetries > 0));
+}
+
+function isRetryableError(error: AxiosError): boolean {
+  // Network errors (no response received)
+  if (!error.response) return true;
+  // Server errors (5xx)
+  if (error.response.status >= 500) return true;
+  // Request timeout
+  if (error.code === 'ECONNABORTED') return true;
+  return false;
+}
+
+function isRetryableMethod(config: InternalAxiosRequestConfig): boolean {
+  return RETRYABLE_METHODS.has((config.method || '').toLowerCase());
+}
+
+function getRetryDelay(attempt: number): number {
+  const exponentialDelay = RETRY_INITIAL_DELAY_MS * Math.pow(2, attempt);
+  const delay = Math.min(exponentialDelay, RETRY_MAX_DELAY_MS);
+  // Add jitter (±25%) to prevent thundering herd
+  const jitter = delay * 0.25 * (Math.random() * 2 - 1);
+  return delay + jitter;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function retryRequest(
+  error: AxiosError,
+  config: InternalAxiosRequestConfig & { _retryCount?: number },
+): Promise<AxiosResponse> {
+  const attempt = config._retryCount || 0;
+
+  if (attempt >= RETRY_MAX_ATTEMPTS || !isRetryableMethod(config) || !isRetryableError(error)) {
+    throw error;
+  }
+
+  config._retryCount = attempt + 1;
+
+  if (attempt === 0) setRetrying(true);
+
+  const delay = getRetryDelay(attempt);
+  await sleep(delay);
+
+  try {
+    const response = await apiClient(config);
+    setRetrying(false);
+    return response;
+  } catch (retryError) {
+    if (config._retryCount >= RETRY_MAX_ATTEMPTS) {
+      setRetrying(false);
+    }
+    throw retryError;
+  }
+}
+
 /**
  * Axios client configured for HouseFlow API
  * Uses HttpOnly cookies for refresh tokens and in-memory storage for access tokens
@@ -200,9 +281,9 @@ apiClient.interceptors.response.use(
       console.error('Access forbidden:', error.response.data);
     }
 
-    // Handle 500 Server Error
-    if (error.response?.status === 500) {
-      console.error('Server error:', error.response.data);
+    // Retry logic for retryable errors (5xx, network, timeout) on idempotent methods
+    if (originalRequest && isRetryableError(error) && isRetryableMethod(originalRequest)) {
+      return retryRequest(error, originalRequest);
     }
 
     return Promise.reject(error);

--- a/src/HouseFlow.Frontend/src/lib/api/hooks/use-retry-state.ts
+++ b/src/HouseFlow.Frontend/src/lib/api/hooks/use-retry-state.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react';
+import { onRetryStateChange } from '../client';
+
+/**
+ * Hook that tracks whether any API request is currently being retried.
+ * Connects to the Axios retry interceptor via the onRetryStateChange listener.
+ */
+export function useRetryState(): boolean {
+  const [isRetrying, setIsRetrying] = useState(false);
+
+  useEffect(() => {
+    return onRetryStateChange(setIsRetrying);
+  }, []);
+
+  return isRetrying;
+}

--- a/src/HouseFlow.Frontend/src/messages/en.json
+++ b/src/HouseFlow.Frontend/src/messages/en.json
@@ -22,7 +22,8 @@
     "cost": "Cost",
     "somethingWentWrong": "Something went wrong",
     "unexpectedError": "An unexpected error occurred. Please try again.",
-    "tryAgain": "Try again"
+    "tryAgain": "Try again",
+    "retrying": "Retrying connection…"
   },
   "auth": {
     "login": "Sign In",

--- a/src/HouseFlow.Frontend/src/messages/fr.json
+++ b/src/HouseFlow.Frontend/src/messages/fr.json
@@ -22,7 +22,8 @@
     "cost": "Coût",
     "somethingWentWrong": "Une erreur est survenue",
     "unexpectedError": "Une erreur inattendue s'est produite. Veuillez réessayer.",
-    "tryAgain": "Réessayer"
+    "tryAgain": "Réessayer",
+    "retrying": "Reconnexion en cours…"
   },
   "auth": {
     "login": "Se connecter",

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -133,6 +133,16 @@ Un hook PreToolUse bloque `git push` si le marqueur n'existe pas ou date de plus
 **Cause:** Toutes les PRs partageaient `ephemeral.tfstate` avec `for_each = var.pr_envs`. Mais `pr_envs` ne contenait que la PR courante, donc Terraform voyait les autres comme orphelines. Le lock global sérialisait tout. `cancel-in-progress: true` pouvait tuer un apply en cours. `force-unlock` pouvait corrompre le state d'une autre PR.
 **Leçon:** Un state Terraform par environnement déployé indépendamment. Pour les environnements éphémères : `ephemeral-pr-{N}.tfstate` via `-backend-config="key=..."`. Plus de `for_each`, plus de `-target`, plus de lock global, plus de `force-unlock`. Chaque PR est totalement isolée. Même pattern que la séparation prod/preprod (leçon 2026-03-29).
 
+### Retry API : ne pas retenter les requêtes non-idempotentes
+**Contexte:** Implémentation du retry automatique pour les appels API (issue #42).
+**Cause:** Un POST qui échoue avec un timeout peut avoir été traité côté serveur. Retenter = risque de doublon (double création, double envoi d'invitation, etc.).
+**Leçon:** Ne retenter automatiquement que les méthodes idempotentes (GET, PUT, DELETE, HEAD, OPTIONS). Pour POST/PATCH, laisser l'utilisateur décider de réessayer manuellement. Si un endpoint POST est garanti idempotent (ex: clé d'idempotence), on peut opt-in via un header custom.
+
+### Éviter le double-retry entre Axios et React Query
+**Contexte:** React Query a un `retry: 1` par défaut, et on ajoute un retry dans l'intercepteur Axios.
+**Cause:** Les deux couches retentent indépendamment, ce qui multiplie les tentatives (ex: 3 × 2 = 6 requêtes au lieu de 3).
+**Leçon:** Quand le retry est géré au niveau Axios (intercepteur centralisé), désactiver `retry` dans React Query (`retry: false`). Un seul endroit doit gérer le retry pour garder un comportement prévisible.
+
 ---
 
 ## Template


### PR DESCRIPTION
## Summary
Implements automatic retry logic for failed API requests with exponential backoff, jitter, and a visual indicator. This improves resilience against transient network failures and server errors without requiring user intervention.

## Key Changes

### Core Retry Logic (`src/lib/api/client.ts`)
- Added exponential backoff retry mechanism (100ms → 200ms → 400ms) with ±25% jitter
- Maximum 3 retry attempts before permanent failure
- Retries only idempotent HTTP methods (GET, PUT, DELETE, HEAD, OPTIONS)
- Retries only on transient errors: 5xx status codes, network errors, and timeouts
- Client errors (4xx) are never retried
- Non-idempotent methods (POST, PATCH) are never retried to prevent duplicate operations
- Exported `onRetryStateChange()` listener pattern for UI state tracking

### UI Components
- **RetryIndicator** (`src/components/ui/retry-indicator.tsx`): Discrete amber banner with spinner, shown during active retries
- **useRetryState hook** (`src/lib/api/hooks/use-retry-state.ts`): React hook to subscribe to retry state changes
- Integrated RetryIndicator into root layout for global visibility

### Configuration Updates
- Disabled React Query's built-in retry (`retry: false`) to avoid double-retrying at multiple layers
- Added i18n translations for retry message ("Retrying connection…" / "Reconnexion en cours…")

### Testing
- Comprehensive test suite for retry logic (`src/lib/api/__tests__/retry.test.ts`): 179 lines covering error handling, max attempts, listener notifications
- RetryIndicator component tests (`src/components/ui/__tests__/retry-indicator.test.tsx`): Visibility, state transitions, accessibility

### Documentation
- Added user story US-140 to `specs/user-stories.md` with acceptance criteria
- Updated PROJECT_KNOWLEDGE.md with implementation details

## Implementation Details
- Retry state is tracked via a listener pattern rather than global state, allowing multiple UI components to subscribe
- Jitter prevents thundering herd problem when multiple clients retry simultaneously
- Request config is mutated with `_retryCount` to track attempts across interceptor calls
- Retry listeners are notified at the start and end of retry sequences for accurate UI state

https://claude.ai/code/session_012XS5e75utgMbt7PRsF6vyo