### PR TITLE
Add audit context middleware for automatic request attribution

### DIFF
--- a/src/HouseFlow.API/Middleware/AuditContextMiddleware.cs
+++ b/src/HouseFlow.API/Middleware/AuditContextMiddleware.cs
@@ -1,0 +1,43 @@
+using System.Security.Claims;
+using HouseFlow.Infrastructure.Data;
+
+namespace HouseFlow.API.Middleware;
+
+/// <summary>
+/// Middleware that sets the audit context (user identity, IP, user agent)
+/// on the DbContext for every authenticated request, ensuring all database
+/// changes are properly attributed in the AuditLogs table.
+/// </summary>
+public class AuditContextMiddleware
+{
+    private readonly RequestDelegate _next;
+
+    public AuditContextMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public async Task InvokeAsync(HttpContext context, HouseFlowDbContext dbContext)
+    {
+        Guid? userId = null;
+        string? username = null;
+
+        if (context.User.Identity?.IsAuthenticated == true)
+        {
+            var userIdClaim = context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            if (Guid.TryParse(userIdClaim, out var parsed))
+            {
+                userId = parsed;
+            }
+
+            username = context.User.FindFirst(ClaimTypes.Email)?.Value;
+        }
+
+        var ipAddress = context.Connection.RemoteIpAddress?.ToString();
+        var userAgent = context.Request.Headers.UserAgent.ToString();
+
+        dbContext.SetAuditContext(userId, username, ipAddress, userAgent);
+
+        await _next(context);
+    }
+}

--- a/src/HouseFlow.API/Program.cs
+++ b/src/HouseFlow.API/Program.cs
@@ -427,6 +427,9 @@ app.UseCors();
 app.UseAuthentication();
 app.UseAuthorization();
 
+// Set audit context (user identity, IP, user agent) for every request
+app.UseMiddleware<AuditContextMiddleware>();
+
 app.MapControllers();
 
 app.MapHealthChecks("/health");

--- a/src/HouseFlow.Infrastructure/Services/AuthService.cs
+++ b/src/HouseFlow.Infrastructure/Services/AuthService.cs
@@ -49,7 +49,7 @@ public class AuthService : IAuthService
             CreatedAt = DateTime.UtcNow
         };
 
-        // Set audit context for this operation
+        // Override audit context with registration email (no JWT available for this endpoint)
         _context.SetAuditContext(null, request.Email, ipAddress);
 
         _context.Users.Add(user);
@@ -142,7 +142,7 @@ public class AuthService : IAuthService
 
         _logger.LogInformation("User logged in successfully: {UserId}", user.Id);
 
-        // Set audit context
+        // Override audit context with authenticated user (no JWT available for this endpoint)
         _context.SetAuditContext(user.Id, user.Email, ipAddress);
 
         // Generate tokens
@@ -170,14 +170,14 @@ public class AuthService : IAuthService
             throw new UnauthorizedAccessException("Invalid or expired refresh token");
         }
 
+        // Override audit context (no JWT available for this endpoint)
+        _context.SetAuditContext(refreshToken.UserId, refreshToken.User?.Email, ipAddress);
+
         // Replace old refresh token with new one (rotation)
         var newRefreshToken = await RotateRefreshToken(refreshToken, ipAddress);
         await _context.SaveChangesAsync();
 
         _logger.LogInformation("Token refreshed for user: {UserId}", refreshToken.UserId);
-
-        // Set audit context
-        _context.SetAuditContext(refreshToken.UserId, refreshToken.User?.Email, ipAddress);
 
         // Generate new JWT
         var jwtToken = GenerateJwtToken(refreshToken.UserId, refreshToken.User?.Email ?? "");


### PR DESCRIPTION
## Summary
This PR introduces an `AuditContextMiddleware` that automatically captures and sets audit context (user identity, IP address, and user agent) for every authenticated request, ensuring all database changes are properly attributed in the AuditLogs table without requiring manual context setup in each endpoint.

## Key Changes
- **New Middleware**: Added `AuditContextMiddleware` that extracts user identity from claims, IP address, and user agent from the HTTP context and sets them on the DbContext before request processing
- **Middleware Registration**: Registered the middleware in the request pipeline after authentication/authorization to ensure user claims are available
- **Audit Context Ordering**: Reordered audit context setup in `RefreshTokenAsync` to occur before token rotation, ensuring the audit log captures the correct sequence of operations
- **Comment Clarifications**: Updated comments in `AuthService` to clarify that manual audit context overrides are necessary for endpoints without JWT tokens (registration, login, token refresh)

## Implementation Details
- The middleware extracts the user ID from `ClaimTypes.NameIdentifier` and email from `ClaimTypes.Email` claims
- Falls back gracefully for unauthenticated requests by setting `userId` and `username` to null
- Captures remote IP address and user agent from the HTTP context
- Positioned in the middleware pipeline after `UseAuthentication()` and `UseAuthorization()` to ensure claims are populated
- Maintains backward compatibility with existing manual audit context calls in auth endpoints that lack JWT tokens

https://claude.ai/code/session_01Vf1KEYsXCW4tXo7jP4eer4