### PR TITLE
Add client-side validation for required device type field

### DIFF
--- a/src/HouseFlow.Frontend/e2e/tests/device-management.spec.ts
+++ b/src/HouseFlow.Frontend/e2e/tests/device-management.spec.ts
@@ -20,6 +20,20 @@ test.describe('User Flow 2: Device Management', () => {
     await expect(page.getByText('Chaudière Sous-sol')).toBeVisible();
   });
 
+  test('Show validation error when creating device without type', async ({ authenticatedPage: page }) => {
+    // Navigate to device creation page
+    await page.getByRole('button', { name: /add device|ajouter un appareil/i }).first().click();
+    await expect(page).toHaveURL(/\/fr\/houses\/[a-f0-9-]+\/devices\/new/);
+
+    // Fill only the name, skip type selection
+    await page.getByPlaceholder(/chaudière/i).fill('Appareil Sans Type');
+    await page.getByRole('button', { name: /save|enregistrer/i }).click();
+
+    // Should stay on the form and show a validation error for the type field
+    await expect(page).toHaveURL(/\/fr\/houses\/[a-f0-9-]+\/devices\/new/);
+    await expect(page.getByText(/veuillez sélectionner un type|please select a device type/i)).toBeVisible();
+  });
+
   test('View all devices for a house', async ({ authenticatedPage: page }) => {
     // User already has "Ma Maison" auto-created and is on the house page
 

--- a/src/HouseFlow.Frontend/src/app/[locale]/(dashboard)/houses/[id]/devices/new/page.tsx
+++ b/src/HouseFlow.Frontend/src/app/[locale]/(dashboard)/houses/[id]/devices/new/page.tsx
@@ -20,11 +20,17 @@ export default function NewDevicePage({ params }: { params: Promise<{ id: string
   const [brand, setBrand] = useState('');
   const [model, setModel] = useState('');
   const [installDate, setInstallDate] = useState('');
+  const [typeError, setTypeError] = useState(false);
 
   const createDeviceMutation = useCreateDevice(houseId);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!type) {
+      setTypeError(true);
+      return;
+    }
+    setTypeError(false);
     createDeviceMutation.mutate({
       name,
       type,
@@ -90,8 +96,8 @@ export default function NewDevicePage({ params }: { params: Promise<{ id: string
                 <label htmlFor="type" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                   {t('deviceType')}
                 </label>
-                <Select value={type} onValueChange={setType}>
-                  <SelectTrigger className="w-full">
+                <Select value={type} onValueChange={(value) => { setType(value); setTypeError(false); }}>
+                  <SelectTrigger className={`w-full ${typeError ? 'border-red-500' : ''}`}>
                     <SelectValue placeholder={tCommon('selectType')} />
                   </SelectTrigger>
                   <SelectContent>
@@ -102,6 +108,9 @@ export default function NewDevicePage({ params }: { params: Promise<{ id: string
                     ))}
                   </SelectContent>
                 </Select>
+                {typeError && (
+                  <p className="text-sm text-red-500 mt-1">{t('typeRequired')}</p>
+                )}
               </div>
 
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">

--- a/src/HouseFlow.Frontend/src/messages/en.json
+++ b/src/HouseFlow.Frontend/src/messages/en.json
@@ -136,6 +136,7 @@
     "noDevicesYet": "No Devices Yet",
     "noDevicesDescription": "Add your first device to start tracking your home maintenance.",
     "createError": "Failed to create device. Please try again.",
+    "typeRequired": "Please select a device type.",
     "maintenanceTypes": "Maintenance Types",
     "addType": "Add Type",
     "noMaintenanceTypes": "No maintenance types",

--- a/src/HouseFlow.Frontend/src/messages/fr.json
+++ b/src/HouseFlow.Frontend/src/messages/fr.json
@@ -136,6 +136,7 @@
     "noDevicesYet": "Aucun Appareil",
     "noDevicesDescription": "Ajoutez votre premier appareil pour commencer le suivi de l'entretien de votre maison.",
     "createError": "Échec de la création de l'appareil. Veuillez réessayer.",
+    "typeRequired": "Veuillez sélectionner un type d'appareil.",
     "maintenanceTypes": "Types d'entretien",
     "addType": "Ajouter",
     "noMaintenanceTypes": "Aucun type d'entretien",

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -135,6 +135,15 @@ Un hook PreToolUse bloque `git push` si le marqueur n'existe pas ou date de plus
 
 ---
 
+## 2026-04-01
+
+### Toujours ajouter une validation côté client pour les champs obligatoires des formulaires
+**Contexte:** Le formulaire de création d'appareil permettait de soumettre sans sélectionner de type. L'API renvoyait une 400 validation error, mais le frontend affichait un message générique ("Échec de la création de l'appareil. Veuillez réessayer.") sans indiquer quel champ posait problème.
+**Cause:** La validation reposait uniquement sur le backend (Data Annotations `[Required]`). Le frontend n'avait aucune validation côté client pour le champ `type` (un `<Select>` Radix UI qui ne supporte pas l'attribut HTML `required`).
+**Leçon:** Pour chaque formulaire de création/édition, TOUJOURS ajouter une validation côté client sur les champs obligatoires, en plus de la validation backend. En particulier pour les composants Radix UI (Select, etc.) qui ne supportent pas `required` nativement : vérifier manuellement dans le `handleSubmit` et afficher un message d'erreur inline spécifique au champ. Le message d'erreur doit indiquer clairement quel champ est manquant, pas un message générique.
+
+---
+
 ## Template
 
 ### [Titre court du problème]


### PR DESCRIPTION
## Summary
Added client-side validation for the device type field in the device creation form to provide immediate, field-specific error feedback to users instead of relying solely on backend validation.

## Key Changes
- **Form Validation**: Added `typeError` state to track validation status of the device type field
- **Submit Handler**: Implemented validation check in `handleSubmit` to prevent form submission when type is not selected
- **Error Display**: 
  - Added red border styling to the Select trigger when validation fails
  - Display inline error message below the type field with localized text
  - Clear error state when user selects a type
- **Localization**: Added `typeRequired` translation keys in both English and French message files
- **E2E Test**: Added test case to verify validation error is shown when attempting to create a device without selecting a type

## Implementation Details
- The validation clears the error state when the user interacts with the Select component, providing immediate feedback
- Error message is bilingual (English: "Please select a device type." / French: "Veuillez sélectionner un type d'appareil.")
- The form remains on the creation page when validation fails, allowing users to correct the error
- This addresses the issue where Radix UI's Select component doesn't support the native HTML `required` attribute, necessitating manual validation

https://claude.ai/code/session_01FtuJWZV4uTg3QHakEbWkuT